### PR TITLE
Change 'auto' behavior of validation, validation returns offending/unknown keys

### DIFF
--- a/src/python/CMSMonitoring/StompAMQ.py
+++ b/src/python/CMSMonitoring/StompAMQ.py
@@ -207,8 +207,7 @@ class StompAMQ(object):
         return
 
     def make_notification(self, payload, docType, docId=None, producer=None, ts=None, metadata=None,
-                          dataSubfield="data", schema=None, returnOffendingKeys=False,
-                          dropOffendingKeys=False, dropUnknownKeys=False):
+                          dataSubfield="data", schema=None, dropOffendingKeys=False, dropUnknownKeys=False):
         """
         Produce a notification from a single payload, adding the necessary
         headers and metadata. Generic metadata is generated to include a

--- a/src/python/CMSMonitoring/StompAMQ.py
+++ b/src/python/CMSMonitoring/StompAMQ.py
@@ -50,9 +50,11 @@ def validate(doc, schema='auto', verbose=False):
         return validate_schema(_schemas.schemas()[schema], doc, verbose)
 
     else:
-        for sname, sch in _schemas.schemas().items():
-            if validate_schema(sch, doc, verbose):
-                return True
+        logging.warning('No validation schema provided, comparing all docs to the first one')
+        with open('auto_schema.json', 'w') as schfile:
+            json.dump(doc, schfile, indent=2, sort_keys=True)
+        _local_schemas['auto'] = doc
+        return True
 
     return False
 

--- a/src/python/CMSMonitoring/Validator.py
+++ b/src/python/CMSMonitoring/Validator.py
@@ -48,7 +48,8 @@ VALIDATORS = {}
 
 class JsonSchemaValidator(object):
     "Python 2.X implementation of validator based on jsonschema package"
-    def __init__(self, schema):
+    def __init__(self, schema, loglevel=logging.WARNING):
+        self.loglevel = loglevel
         shash = md5hash(schema)
         if shash in VALIDATORS:
             self.validator = VALIDATORS[shash]
@@ -56,13 +57,11 @@ class JsonSchemaValidator(object):
             self.validator = jsonschema.validators.validator_for(schema)(schema)
             self.validator.check_schema(schema)
             VALIDATORS[shash] = self.validator
-    def validate_schema(self, doc, verbose=False):
+    def validate_schema(self, doc):
         try:
             self.validator.validate(doc)
         except Exception as exp:
-            if verbose:
-                print("Fail schema validation")
-                print(str(exp))
+            logging.log(self.loglevel, "Fail schema validation: {}".format(str(exp)))
             return False
         return True
 
@@ -107,14 +106,14 @@ class Schemas(object):
             self.sdict[sname] = json.load(open(os.path.join(fdir, sname)))
         return self.sdict
 
-def validate_jsonschema(schema, doc, verbose=False):
+def validate_jsonschema(schema, doc, loglevel=logging.WARNING):
     """
     Jsonschema implementation of validate schema of a given document
     :param schema: schema to be used
     :param doc: document to be validated
     """
-    validator = JsonSchemaValidator(schema)
-    return validator.validate_schema(doc, verbose)
+    validator = JsonSchemaValidator(schema, loglevel=loglevel)
+    return validator.validate_schema(doc)
 
 def etype(val):
     "Helper function to deduce type of given value either from python based type or jsonschema"
@@ -133,7 +132,7 @@ def etype(val):
 
     return type(val)
 
-def _validate_schema(schema, doc):
+def _validate_schema(schema, doc, loglevel=logging.WARNING):
     """
     Python based implementation to validate schema of a given document
     :param schema: schema to be used
@@ -145,34 +144,34 @@ def _validate_schema(schema, doc):
 
     for key, val in doc.items():
         if key not in schema:
-            logging.warning("{}: unknown key={}, val={}".format(base, key, repr(val)))
+            logging.log(loglevel, "{}: unknown key={}, val={}".format(base, key, repr(val)))
             continue
 
         if isinstance(val, types.DictType):
             sub_schema = _validate_schema(schema[key], val)
             if not sub_schema:
-                logging.warning("{}: for sub schema={} val={} has wrong data-types".format(base, schema[key], repr(val)))
+                logging.log(loglevel, "{}: for sub schema={} val={} has wrong data-types".format(base, schema[key], repr(val)))
                 return False
 
         expect = schema[key]
         if isinstance(val, types.ListType):
             if len(set([type(x) for x in val])) != 1:
-                logging.warning("{}: for key={} val={} has inconsistent data-types".format(base, key, repr(val)))
+                logging.log(loglevel, "{}: for key={} val={} has inconsistent data-types".format(base, key, repr(val)))
                 return False
 
             if not isinstance(val[0], etype(expect[0])):
-                logging.warning("{}: for key={} val={} has incorrect data-type in list, found {} expect {}".format(
+                logging.log(loglevel, "{}: for key={} val={} has incorrect data-type in list, found {} expect {}".format(
                              base, key, repr(val), type(val[0]), etype(expect[0])))
                 return False
 
         if val != None and not isinstance(val, etype(expect)):
-            logging.warning("{}: for key={} val={} has incorrect data-type, found {} expect {}".format(
+            logging.log(loglevel, "{}: for key={} val={} has incorrect data-type, found {} expect {}".format(
                              base, key, repr(val), type(val), etype(expect)))
             return False
 
     return True
 
-def validate_schema(schema, doc, verbose=False):
+def validate_schema(schema, doc, loglevel=logging.WARNING):
     """
     validates given document against given shema
     :param schema: schema to be used
@@ -180,9 +179,9 @@ def validate_schema(schema, doc, verbose=False):
     """
     if '$schema' in schema:
         logging.debug("using jsonschema validator")
-        return validate_jsonschema(schema, doc, verbose)
+        return validate_jsonschema(schema, doc, loglevel=loglevel)
     logging.debug("using python based validator")
-    return _validate_schema(schema, doc)
+    return _validate_schema(schema, doc, loglevel=loglevel)
 
 class Validator(object):
     def __init__(self, schema):


### PR DESCRIPTION
- When not choosing a validation schema, the validation now compares all docs to the first one by default (rather than trying out all possible schemas for every document). This will work ok for documents with a very fixed structure, i.e. where the first one is representative, but obviously goes wrong if documents are inhomogeneous or if the first one is a bad example.

- Users can now choose which log level the validation should use to issue feedback. In the same spirit, I removed the `verbose` toggle and replaced it with the log level.

- The validation now always runs on the entire document and collects a list of offending and unknown keys and then returns these. Added options to `make_notification` to drop these from the notification (either or both) and to return them to clients.