### PR TITLE
Script to generate the grafana datasources list

### DIFF
--- a/src/python/CMSMonitoring/datasourcesList.py
+++ b/src/python/CMSMonitoring/datasourcesList.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+# Author: Christian Ariza <christian.ariza AT gmail [DOT] com>
+import os
+import sys
+import json
+import argparse
+import requests
+
+try:
+    import urllib.request as ulib # python 3.X
+    import urllib.parse as parser
+except ImportError:
+    import urllib2 as ulib # python 2.X
+    import urllib as parser
+    
+class OptionParser():
+    def __init__(self):
+        "User based option parser"
+        desc = """
+This app creates a json file with the name, id, and type of datasource in the user organization. 
+It requires a admin token from grafana. 
+               """
+        self.parser = argparse.ArgumentParser(prog='PROG', usage=desc)
+        self.parser.add_argument("--token", action="store",
+            dest="token", default=None, help="Admin token")
+        self.parser.add_argument("--url", action="store",
+            dest="url", default="https://monit-grafana.cern.ch", help="MONIT URL")
+        self.parser.add_argument("--output", action="store",
+            dest="output", default=sys.stdout, help="output file")
+
+def get_datasources(token, base='https://monit-grafana.cern.ch'):
+    headers = {
+        'Authorization': 'Bearer {}'.format(token),
+        'Content-type': 'application/x-ndjson', 
+        'Accept': 'application/json'
+              }
+    uri = base+'/api/datasources'
+    response = requests.get(uri, headers=headers)
+    fullResponse = json.loads(response.text)
+    return {x['name']: {'id': x['id'], 'type': x['type'], 'database': x['database']} for x in fullResponse}
+
+    
+def main():
+    "Main function"
+    optmgr  = OptionParser()
+    opts = optmgr.parser.parse_args()
+    token = os.getenv('GRAFANA_ADMIN_TOKEN', opts.token) 
+    output = opts.output
+    base = opts.url
+    if not token:
+        print ("The token is required either using --token with the value or using the GRAFANA_ADMIN_TOKEN env variable")
+        sys.exit(-1) 
+    datasources = get_datasources(token, base=base)
+    if not output:
+        json.dump(datasources, sys.stdout, indent=4)
+    else:
+        with open(output,'w') as _output_file:
+            json.dump(datasources, _output_file, indent=4)
+if __name__ == '__main__':
+    main()

--- a/static/datasources.json
+++ b/static/datasources.json
@@ -1,0 +1,227 @@
+{
+    "monit_idb_monitoring": {
+        "type": "influxdb", 
+        "id": 9109, 
+        "database": "monit_production_monitoring"
+    }, 
+    "monit_idb_cmsjm_old": {
+        "type": "influxdb", 
+        "id": 8991, 
+        "database": "monit_production_condor"
+    }, 
+    "monit_idb_collectd_protocol": {
+        "type": "influxdb", 
+        "id": 9094, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_es_condor_2019": {
+        "type": "elasticsearch", 
+        "id": 9014, 
+        "database": "[monit_prod_condor_raw_metric_v002-2019*]"
+    }, 
+    "monit_idb_eos": {
+        "type": "influxdb", 
+        "id": 8531, 
+        "database": "monit_production_eos"
+    }, 
+    "monit_idb_collectd_vmem": {
+        "type": "influxdb", 
+        "id": 9105, 
+        "database": "monit_production_collectd"
+    }, 
+    "cmsweb-k8s": {
+        "type": "prometheus", 
+        "id": 8488, 
+        "database": ""
+    }, 
+    "monit_idb_collectd_uptime": {
+        "type": "influxdb", 
+        "id": 9100, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_idb_rebus": {
+        "type": "influxdb", 
+        "id": 9115, 
+        "database": "monit_production_rebus"
+    }, 
+    "monit_idb_collectd_memory": {
+        "type": "influxdb", 
+        "id": 9092, 
+        "database": "monit_production_collectd"
+    }, 
+    "SCHEDD": {
+        "type": "elasticsearch", 
+        "id": 8980, 
+        "database": "[monit_prod_crab_raw_schedd-*]"
+    }, 
+    "monit_idb_collectd_df": {
+        "type": "influxdb", 
+        "id": 9089, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_idb_cmsjm": {
+        "type": "influxdb", 
+        "id": 7731, 
+        "database": "monit_production_cmsjm"
+    }, 
+    "monit_idb_collectd_swap": {
+        "type": "influxdb", 
+        "id": 9096, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_idb_xsls": {
+        "type": "influxdb", 
+        "id": 8036, 
+        "database": "monit_production_xsls"
+    }, 
+    "monit_idb_collectd_heartbeat": {
+        "type": "influxdb", 
+        "id": 9086, 
+        "database": "monit_production_collectd"
+    }, 
+    "TASKWORKER": {
+        "type": "elasticsearch", 
+        "id": 8981, 
+        "database": "[monit_prod_crab_raw_taskworker-*]"
+    }, 
+    "es-cms": {
+        "type": "elasticsearch", 
+        "id": 8983, 
+        "database": "[cms-20*]"
+    }, 
+    "monit_prod_phedex_dbs": {
+        "type": "elasticsearch", 
+        "id": 7571, 
+        "database": "[monit_prod_phedex_dbs_*]"
+    }, 
+    "monit_idb_transfers": {
+        "type": "influxdb", 
+        "id": 8035, 
+        "database": "monit_production_transfer"
+    }, 
+    "monit_prod_wmagentqa": {
+        "type": "elasticsearch", 
+        "id": 8429, 
+        "database": "[monit_prod_wmagentqa_*]"
+    }, 
+    "monit_kpi": {
+        "type": "elasticsearch", 
+        "id": 8533, 
+        "database": "[monit_prod_kpi*]"
+    }, 
+    "monit_idb_availability": {
+        "type": "influxdb", 
+        "id": 9107, 
+        "database": "monit_production_service_availability"
+    }, 
+    "monit_idb_collectd_load": {
+        "type": "influxdb", 
+        "id": 9091, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_idb_kpis": {
+        "type": "influxdb", 
+        "id": 8532, 
+        "database": "monit_production_kpi"
+    }, 
+    "monit_idb_databases": {
+        "type": "influxdb", 
+        "id": 8530, 
+        "database": "monit_production_databases"
+    }, 
+    "monit_es_condor": {
+        "type": "elasticsearch", 
+        "id": 8787, 
+        "database": "[monit_prod_condor_raw_metric_v002*]"
+    }, 
+    "es-cms-cmssdt-relvals": {
+        "type": "elasticsearch", 
+        "id": 9015, 
+        "database": "cmssdt-relvals_stats_summary-*"
+    }, 
+    "monit_prod_wmagent": {
+        "type": "elasticsearch", 
+        "id": 7617, 
+        "database": "[monit_prod_wmagent_*]"
+    }, 
+    "cmsweb-prometheus": {
+        "type": "prometheus", 
+        "id": 9041, 
+        "database": ""
+    }, 
+    "monit_prod_tier0wmagent": {
+        "type": "elasticsearch", 
+        "id": 9113, 
+        "database": "[monit_prod_tier0wmagent_raw_metric_v0.3*]"
+    }, 
+    "monit_crab": {
+        "type": "elasticsearch", 
+        "id": 8978, 
+        "database": "[monit_prod_crab_*]"
+    }, 
+    "CMSWEB": {
+        "type": "graphite", 
+        "id": 8973, 
+        "database": ""
+    }, 
+    "monit_idb_alarms": {
+        "type": "influxdb", 
+        "id": 8528, 
+        "database": "monit_production_alarm"
+    }, 
+    "SI-condor": {
+        "type": "elasticsearch", 
+        "id": 8993, 
+        "database": "[monit_prod_cms_raw_si_condor_*]"
+    }, 
+    "monit_idb_collectd_cpu": {
+        "type": "influxdb", 
+        "id": 9088, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_condor": {
+        "type": "elasticsearch", 
+        "id": 7668, 
+        "database": "[monit_prod_condor_*]"
+    }, 
+    "monit_idb_collectd_processes": {
+        "type": "influxdb", 
+        "id": 9093, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_idb_collectd_users": {
+        "type": "influxdb", 
+        "id": 9103, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_eoscmsquotas": {
+        "type": "elasticsearch", 
+        "id": 9003, 
+        "database": "[monit_prod_eoscmsquotas_*]"
+    }, 
+    "monit_idb_collectd_interface": {
+        "type": "influxdb", 
+        "id": 9090, 
+        "database": "monit_production_collectd"
+    }, 
+    "monit_es_condor_tasks": {
+        "type": "elasticsearch", 
+        "id": 9039, 
+        "database": "[monit_prod_condor_raw_task_v002-*]"
+    }, 
+    "WMArchive": {
+        "type": "elasticsearch", 
+        "id": 7572, 
+        "database": "[monit_prod_wmarchive_*]"
+    }, 
+    "monit_es_toolsandint": {
+        "type": "elasticsearch", 
+        "id": 9040, 
+        "database": "[monit_prod_toolsandint*]"
+    }, 
+    "monit_idb_collectd_tcpconnections": {
+        "type": "influxdb", 
+        "id": 9098, 
+        "database": "monit_production_collectd"
+    }
+}


### PR DESCRIPTION
Script to generate the grafana datasources list and the current list.

TODO: Next step is to modify monit.py to use the static list to get the datasource type and the table when is not specified. 
