### PR TITLE
Remove numeric CNs from the dn

### DIFF
--- a/doc/logstash/cmsweb.conf
+++ b/doc/logstash/cmsweb.conf
@@ -163,6 +163,12 @@ filter {
 #        "request", "\]", ""
 #    ]
 #  }
+#Remove the numeric CNs from the client dn. 
+  mutate {
+    gsub =>  [
+        "dn","/CN=\d+",""
+    ]
+  }
 }
 
 # send results (JSON records) to local file


### PR DESCRIPTION
It assumes that if a "cn" starts with a number, is numeric.  It should be a safe assumption (and make the regex much simpler).

![image](https://user-images.githubusercontent.com/4405564/60584121-ade59f80-9d8c-11e9-8578-0c95c2fc9acf.png)
