### PR TITLE
Use the external datasources list

### DIFF
--- a/bin/monit
+++ b/bin/monit
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 # find out where CMSMonitoring is installed on a system
-root=`python -c "import CMSMonitoring; print '/'.join(CMSMonitoring.__file__.split('/')[:-1])"`
+root=$(python -c "import CMSMonitoring; print('/'.join(CMSMonitoring.__file__.split('/')[:-1]))")
+MONIT_HOME="$(cd "$(dirname "$0")" && pwd)"
+export MONIT_DB_DICT_FILE="$MONIT_HOME/../static/datasources.json"
 # run actual script
 python $root/monit.py ${1+"$@"}

--- a/bin/monit
+++ b/bin/monit
@@ -3,6 +3,6 @@
 # find out where CMSMonitoring is installed on a system
 root=$(python -c "import CMSMonitoring; print('/'.join(CMSMonitoring.__file__.split('/')[:-1]))")
 MONIT_HOME="$(cd "$(dirname "$0")" && pwd)"
-export MONIT_DB_DICT_FILE="$MONIT_HOME/../static/datasources.json"
+export MONIT_DB_DICT_FILE="${MONIT_DB_DICT_FILE:-$MONIT_HOME/../static/datasources.json}"
 # run actual script
-python $root/monit.py ${1+"$@"}
+python "$root/monit.py" ${1+"$@"}

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ def main():
         data_files           = [
             ('{}/CMSMonitoring/schemas'.format(lpath), datafiles('schemas', '*.json')),
             ('{}/CMSMonitoring/jsonschemas'.format(lpath), datafiles('jsonschemas', '*.schema')),
+            ('{}/CMSMonitoring/static'.format(lpath), datafiles('static', '*.json')),
             ],
         classifiers          = [
             "Programming Language :: Python",

--- a/src/python/CMSMonitoring/datasourcesList.py
+++ b/src/python/CMSMonitoring/datasourcesList.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # Author: Christian Ariza <christian.ariza AT gmail [DOT] com>
 import os
 import sys
@@ -8,54 +8,70 @@ import argparse
 import requests
 
 try:
-    import urllib.request as ulib # python 3.X
+    import urllib.request as ulib  # python 3.X
     import urllib.parse as parser
 except ImportError:
-    import urllib2 as ulib # python 2.X
+    import urllib2 as ulib  # python 2.X
     import urllib as parser
-    
-class OptionParser():
+
+
+class OptionParser:
     def __init__(self):
         "User based option parser"
         desc = """
 This app creates a json file with the name, id, and type of datasource in the user organization. 
 It requires a admin token from grafana. 
                """
-        self.parser = argparse.ArgumentParser(prog='PROG', usage=desc)
-        self.parser.add_argument("--token", action="store",
-            dest="token", default=None, help="Admin token")
-        self.parser.add_argument("--url", action="store",
-            dest="url", default="https://monit-grafana.cern.ch", help="MONIT URL")
-        self.parser.add_argument("--output", action="store",
-            dest="output", default=sys.stdout, help="output file")
+        self.parser = argparse.ArgumentParser(prog="PROG", usage=desc)
+        self.parser.add_argument(
+            "--token", action="store", dest="token", default=None, help="Admin token"
+        )
+        self.parser.add_argument(
+            "--url",
+            action="store",
+            dest="url",
+            default="https://monit-grafana.cern.ch",
+            help="MONIT URL",
+        )
+        self.parser.add_argument(
+            "--output", action="store", dest="output", default=None, help="output file"
+        )
 
-def get_datasources(token, base='https://monit-grafana.cern.ch'):
+
+def get_datasources(token, base="https://monit-grafana.cern.ch"):
     headers = {
-        'Authorization': 'Bearer {}'.format(token),
-        'Content-type': 'application/x-ndjson', 
-        'Accept': 'application/json'
-              }
-    uri = base+'/api/datasources'
+        "Authorization": "Bearer {}".format(token),
+        "Content-type": "application/x-ndjson",
+        "Accept": "application/json",
+    }
+    uri = base + "/api/datasources"
     response = requests.get(uri, headers=headers)
     fullResponse = json.loads(response.text)
-    return {x['name']: {'id': x['id'], 'type': x['type'], 'database': x['database']} for x in fullResponse}
+    return {
+        x["name"]: {"id": x["id"], "type": x["type"], "database": x["database"]}
+        for x in fullResponse
+    }
 
-    
+
 def main():
     "Main function"
-    optmgr  = OptionParser()
+    optmgr = OptionParser()
     opts = optmgr.parser.parse_args()
-    token = os.getenv('GRAFANA_ADMIN_TOKEN', opts.token) 
+    token = os.getenv("GRAFANA_ADMIN_TOKEN", opts.token)
     output = opts.output
     base = opts.url
     if not token:
-        print ("The token is required either using --token with the value or using the GRAFANA_ADMIN_TOKEN env variable")
-        sys.exit(-1) 
+        print(
+            "The token is required either using --token with the value or using the GRAFANA_ADMIN_TOKEN env variable"
+        )
+        sys.exit(-1)
     datasources = get_datasources(token, base=base)
     if not output:
         json.dump(datasources, sys.stdout, indent=4)
     else:
-        with open(output,'w') as _output_file:
+        with open(output, "w") as _output_file:
             json.dump(datasources, _output_file, indent=4)
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/src/python/CMSMonitoring/datasources_list.py
+++ b/src/python/CMSMonitoring/datasources_list.py
@@ -20,7 +20,8 @@ class OptionParser:
         "User based option parser"
         desc = """
 This app creates a json file with the name, id, and type of datasource in the user organization. 
-It requires a admin token from grafana. 
+It requires a admin token from grafana. The token can be set either using the --token option 
+or through the GRAFANA_ADMIN_TOKEN environment variable. 
                """
         self.parser = argparse.ArgumentParser(prog="PROG", usage=desc)
         self.parser.add_argument(

--- a/src/python/CMSMonitoring/monit.py
+++ b/src/python/CMSMonitoring/monit.py
@@ -29,6 +29,9 @@ class OptionParser:
         "User based option parser"
         desc = "CMS MONIT query tool to query "
         desc += "MONIT datatabases via ES/Influx DB queries or key:val pairs\n"
+        desc += "The file containing the definition of the datasources is set using "
+        desc += "the MONIT_DB_DICT_FILE environment variable\n"
+        desc += "It will use by default the static/datasources.json file\n"
         desc += "\n"
         desc += "Example of querying ES DB via key:val pairs:\n"
         desc += '   monit --dbname=monit_prod_wmagent --query="status:Available,sum:35967"\n'
@@ -222,7 +225,9 @@ def __get_db_dict():
 
 def __infer_index(_db, dbname):
     _name_str = (
-        re.match(r"\[{0,1}([^\]]*)\]{0,1}", _db.get("database")).group(1) if _db else dbname
+        re.match(r"\[{0,1}([^\]]*)\]{0,1}", _db.get("database")).group(1)
+        if _db
+        else dbname
     )
     values = [
         index + "*" if not "*" in index else index for index in _name_str.split(",")

--- a/static/datasources.json
+++ b/static/datasources.json
@@ -1,227 +1,297 @@
 {
-    "monit_idb_monitoring": {
-        "type": "influxdb", 
-        "id": 9109, 
-        "database": "monit_production_monitoring"
-    }, 
-    "monit_idb_cmsjm_old": {
-        "type": "influxdb", 
-        "id": 8991, 
-        "database": "monit_production_condor"
-    }, 
-    "monit_idb_collectd_protocol": {
-        "type": "influxdb", 
-        "id": 9094, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_es_condor_2019": {
-        "type": "elasticsearch", 
-        "id": 9014, 
-        "database": "[monit_prod_condor_raw_metric_v002-2019*]"
-    }, 
-    "monit_idb_eos": {
-        "type": "influxdb", 
-        "id": 8531, 
-        "database": "monit_production_eos"
-    }, 
-    "monit_idb_collectd_vmem": {
-        "type": "influxdb", 
-        "id": 9105, 
-        "database": "monit_production_collectd"
-    }, 
-    "cmsweb-k8s": {
-        "type": "prometheus", 
-        "id": 8488, 
-        "database": ""
-    }, 
-    "monit_idb_collectd_uptime": {
-        "type": "influxdb", 
-        "id": 9100, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_idb_rebus": {
-        "type": "influxdb", 
-        "id": 9115, 
-        "database": "monit_production_rebus"
-    }, 
-    "monit_idb_collectd_memory": {
-        "type": "influxdb", 
-        "id": 9092, 
-        "database": "monit_production_collectd"
-    }, 
-    "SCHEDD": {
-        "type": "elasticsearch", 
-        "id": 8980, 
-        "database": "[monit_prod_crab_raw_schedd-*]"
-    }, 
-    "monit_idb_collectd_df": {
-        "type": "influxdb", 
-        "id": 9089, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_idb_cmsjm": {
-        "type": "influxdb", 
-        "id": 7731, 
-        "database": "monit_production_cmsjm"
-    }, 
-    "monit_idb_collectd_swap": {
-        "type": "influxdb", 
-        "id": 9096, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_idb_xsls": {
-        "type": "influxdb", 
-        "id": 8036, 
-        "database": "monit_production_xsls"
-    }, 
-    "monit_idb_collectd_heartbeat": {
-        "type": "influxdb", 
-        "id": 9086, 
-        "database": "monit_production_collectd"
-    }, 
-    "TASKWORKER": {
-        "type": "elasticsearch", 
-        "id": 8981, 
-        "database": "[monit_prod_crab_raw_taskworker-*]"
-    }, 
-    "es-cms": {
-        "type": "elasticsearch", 
-        "id": 8983, 
-        "database": "[cms-20*]"
-    }, 
-    "monit_prod_phedex_dbs": {
-        "type": "elasticsearch", 
-        "id": 7571, 
-        "database": "[monit_prod_phedex_dbs_*]"
-    }, 
-    "monit_idb_transfers": {
-        "type": "influxdb", 
-        "id": 8035, 
-        "database": "monit_production_transfer"
-    }, 
-    "monit_prod_wmagentqa": {
-        "type": "elasticsearch", 
-        "id": 8429, 
-        "database": "[monit_prod_wmagentqa_*]"
-    }, 
-    "monit_kpi": {
-        "type": "elasticsearch", 
-        "id": 8533, 
-        "database": "[monit_prod_kpi*]"
-    }, 
-    "monit_idb_availability": {
-        "type": "influxdb", 
-        "id": 9107, 
-        "database": "monit_production_service_availability"
-    }, 
-    "monit_idb_collectd_load": {
-        "type": "influxdb", 
-        "id": 9091, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_idb_kpis": {
-        "type": "influxdb", 
-        "id": 8532, 
-        "database": "monit_production_kpi"
-    }, 
-    "monit_idb_databases": {
-        "type": "influxdb", 
-        "id": 8530, 
-        "database": "monit_production_databases"
-    }, 
-    "monit_es_condor": {
-        "type": "elasticsearch", 
-        "id": 8787, 
-        "database": "[monit_prod_condor_raw_metric_v002*]"
-    }, 
-    "es-cms-cmssdt-relvals": {
-        "type": "elasticsearch", 
-        "id": 9015, 
-        "database": "cmssdt-relvals_stats_summary-*"
-    }, 
-    "monit_prod_wmagent": {
-        "type": "elasticsearch", 
-        "id": 7617, 
-        "database": "[monit_prod_wmagent_*]"
-    }, 
-    "cmsweb-prometheus": {
-        "type": "prometheus", 
-        "id": 9041, 
-        "database": ""
-    }, 
-    "monit_prod_tier0wmagent": {
-        "type": "elasticsearch", 
-        "id": 9113, 
-        "database": "[monit_prod_tier0wmagent_raw_metric_v0.3*]"
-    }, 
-    "monit_crab": {
-        "type": "elasticsearch", 
-        "id": 8978, 
-        "database": "[monit_prod_crab_*]"
-    }, 
+    "cmssdt-apache-cmssdt": {
+        "id": 9283,
+        "type": "elasticsearch",
+        "database": "cmssdt-apache-cmssdt-*"
+    },
+    "cmssdt-generic": {
+        "id": 9282,
+        "type": "elasticsearch",
+        "database": "cmssdt-*"
+    },
+    "cmssdt-ib-dataset": {
+        "id": 9284,
+        "type": "elasticsearch",
+        "database": "cmssdt-ib-dataset*"
+    },
+    "cmssdt-ib-matrix": {
+        "id": 9285,
+        "type": "elasticsearch",
+        "database": "cmssdt-ib-matrix*"
+    },
+    "cmssdt-ibs": {
+        "id": 9286,
+        "type": "elasticsearch",
+        "database": "cmssdt-ibs*"
+    },
+    "cmssdt-jenkins": {
+        "id": 9287,
+        "type": "elasticsearch",
+        "database": "cmssdt-jenkins-jobs-*"
+    },
+    "cmssdt-jenkins-ibs": {
+        "id": 9301,
+        "type": "elasticsearch",
+        "database": "cmssdt-jenkins-ibs-*"
+    },
+    "cmssdt-scram": {
+        "id": 9288,
+        "type": "elasticsearch",
+        "database": "cmssdt-scram-access*"
+    },
     "CMSWEB": {
-        "type": "graphite", 
-        "id": 8973, 
+        "id": 8973,
+        "type": "graphite",
         "database": ""
-    }, 
-    "monit_idb_alarms": {
-        "type": "influxdb", 
-        "id": 8528, 
-        "database": "monit_production_alarm"
-    }, 
-    "SI-condor": {
-        "type": "elasticsearch", 
-        "id": 8993, 
-        "database": "[monit_prod_cms_raw_si_condor_*]"
-    }, 
-    "monit_idb_collectd_cpu": {
-        "type": "influxdb", 
-        "id": 9088, 
-        "database": "monit_production_collectd"
-    }, 
+    },
+    "cmsweb-k8s": {
+        "id": 8488,
+        "type": "prometheus",
+        "database": ""
+    },
+    "cmsweb-prometheus": {
+        "id": 9041,
+        "type": "prometheus",
+        "database": ""
+    },
+    "es-cms": {
+        "id": 8983,
+        "type": "elasticsearch",
+        "database": "[cms-20*]"
+    },
+    "es-cms-cmssdt-relvals": {
+        "id": 9015,
+        "type": "elasticsearch",
+        "database": "cmssdt-relvals_stats_summary-*"
+    },
+    "ES_cms_rucio_raw_events": {
+        "id": 9269,
+        "type": "elasticsearch",
+        "database": "[monit_prod_cms_rucio_raw_events_*]"
+    },
+    "monit-timber-cms-apache": {
+        "id": 9229,
+        "type": "elasticsearch",
+        "database": "[monit_private_cmsweb_logs_apache-]YYYY-MM-DD"
+    },
     "monit_condor": {
-        "type": "elasticsearch", 
-        "id": 7668, 
-        "database": "[monit_prod_condor_*]"
-    }, 
-    "monit_idb_collectd_processes": {
-        "type": "influxdb", 
-        "id": 9093, 
-        "database": "monit_production_collectd"
-    }, 
-    "monit_idb_collectd_users": {
-        "type": "influxdb", 
-        "id": 9103, 
-        "database": "monit_production_collectd"
-    }, 
+        "id": 7668,
+        "type": "elasticsearch",
+        "database": "[monit_prod_condor*]"
+    },
+    "monit_crab": {
+        "id": 8978,
+        "type": "elasticsearch",
+        "database": "[monit_prod_crab_*]"
+    },
     "monit_eoscmsquotas": {
-        "type": "elasticsearch", 
-        "id": 9003, 
+        "id": 9003,
+        "type": "elasticsearch",
         "database": "[monit_prod_eoscmsquotas_*]"
-    }, 
-    "monit_idb_collectd_interface": {
-        "type": "influxdb", 
-        "id": 9090, 
-        "database": "monit_production_collectd"
-    }, 
+    },
+    "monit_es_condor": {
+        "id": 8787,
+        "type": "elasticsearch",
+        "database": "[monit_prod_condor_raw_metric_v002-]YYYY-MM-DD"
+    },
+    "monit_es_condor_2019": {
+        "id": 9014,
+        "type": "elasticsearch",
+        "database": "[monit_prod_condor_raw_metric_v002-2019-]MM-DD"
+    },
+    "monit_es_condor_overview": {
+        "id": 9236,
+        "type": "elasticsearch",
+        "database": "[monit_prod_condor_raw_overview_*]"
+    },
     "monit_es_condor_tasks": {
-        "type": "elasticsearch", 
-        "id": 9039, 
+        "id": 9039,
+        "type": "elasticsearch",
         "database": "[monit_prod_condor_raw_task_v002-*]"
-    }, 
-    "WMArchive": {
-        "type": "elasticsearch", 
-        "id": 7572, 
-        "database": "[monit_prod_wmarchive_*]"
-    }, 
+    },
     "monit_es_toolsandint": {
-        "type": "elasticsearch", 
-        "id": 9040, 
+        "id": 9040,
+        "type": "elasticsearch",
         "database": "[monit_prod_toolsandint*]"
-    }, 
-    "monit_idb_collectd_tcpconnections": {
-        "type": "influxdb", 
-        "id": 9098, 
+    },
+    "monit_idb_alarms": {
+        "id": 8528,
+        "type": "influxdb",
+        "database": "monit_production_alarm"
+    },
+    "monit_idb_availability": {
+        "id": 9107,
+        "type": "influxdb",
+        "database": "monit_production_service_availability"
+    },
+    "monit_idb_cmsjm": {
+        "id": 7731,
+        "type": "influxdb",
+        "database": "monit_production_cmsjm"
+    },
+    "monit_idb_cmsjm_old": {
+        "id": 8991,
+        "type": "influxdb",
+        "database": "monit_production_cmsjm_old"
+    },
+    "monit_idb_collectd_cpu": {
+        "id": 9088,
+        "type": "influxdb",
         "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_df": {
+        "id": 9089,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_heartbeat": {
+        "id": 9086,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_interface": {
+        "id": 9090,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_load": {
+        "id": 9091,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_memory": {
+        "id": 9092,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_processes": {
+        "id": 9093,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_protocol": {
+        "id": 9094,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_swap": {
+        "id": 9096,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_tcpconnections": {
+        "id": 9098,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_uptime": {
+        "id": 9100,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_users": {
+        "id": 9103,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_collectd_vmem": {
+        "id": 9105,
+        "type": "influxdb",
+        "database": "monit_production_collectd"
+    },
+    "monit_idb_databases": {
+        "id": 8530,
+        "type": "influxdb",
+        "database": "monit_production_databases"
+    },
+    "monit_idb_eos": {
+        "id": 8531,
+        "type": "influxdb",
+        "database": "monit_production_eos"
+    },
+    "monit_idb_kpis": {
+        "id": 8532,
+        "type": "influxdb",
+        "database": "monit_production_kpi"
+    },
+    "monit_idb_monitoring": {
+        "id": 9109,
+        "type": "influxdb",
+        "database": "monit_production_monitoring"
+    },
+    "monit_idb_rebus": {
+        "id": 9115,
+        "type": "influxdb",
+        "database": "monit_production_rebus"
+    },
+    "monit_idb_transfers": {
+        "id": 8035,
+        "type": "influxdb",
+        "database": "monit_production_transfer"
+    },
+    "monit_idb_xsls": {
+        "id": 8036,
+        "type": "influxdb",
+        "database": "monit_production_xsls"
+    },
+    "monit_kpi": {
+        "id": 8533,
+        "type": "elasticsearch",
+        "database": "[monit_prod_kpi*]"
+    },
+    "monit_prod_cms_aaa-ng": {
+        "id": 9231,
+        "type": "elasticsearch",
+        "database": "[monit_prod_cms_raw_aaa-ng*]"
+    },
+    "monit_prod_fts": {
+        "id": 9233,
+        "type": "elasticsearch",
+        "database": "[monit_prod_fts_*]"
+    },
+    "monit_prod_phedex_dbs": {
+        "id": 7571,
+        "type": "elasticsearch",
+        "database": "[monit_prod_phedex_dbs_*]"
+    },
+    "monit_prod_tier0wmagent": {
+        "id": 9113,
+        "type": "elasticsearch",
+        "database": "[monit_prod_tier0wmagent_raw_metric_v0.3*]"
+    },
+    "monit_prod_wmagent": {
+        "id": 7617,
+        "type": "elasticsearch",
+        "database": "[monit_prod_wmagent_*]"
+    },
+    "monit_prod_wmagentqa": {
+        "id": 8429,
+        "type": "elasticsearch",
+        "database": "[monit_prod_wmagentqa_*]"
+    },
+    "Rucio-graphite-dev": {
+        "id": 9259,
+        "type": "graphite",
+        "database": ""
+    },
+    "SCHEDD": {
+        "id": 8980,
+        "type": "elasticsearch",
+        "database": "[monit_prod_crab_raw_schedd-*]"
+    },
+    "SI-condor": {
+        "id": 8993,
+        "type": "elasticsearch",
+        "database": "[monit_prod_cms_raw_si_condor_*]"
+    },
+    "TASKWORKER": {
+        "id": 8981,
+        "type": "elasticsearch",
+        "database": "[monit_prod_crab_raw_taskworker-*]"
+    },
+    "WMArchive": {
+        "id": 7572,
+        "type": "elasticsearch",
+        "database": "[monit_prod_wmarchive_*]"
     }
 }


### PR DESCRIPTION
Instead of a dictionary, we want to use the list generated with datasourcesList.py (from the grafana data sources)

This let us to several changes:

- An option to list the data sources
- Instead of the database name, we require the name of the data source in grafana. 
- we can use the type field in the list to determine the type of the query (influxdb/elasticsearch). 
- the python script and the monit bin expect the file to be at the static/datasources.json path (configurable via env var)

(tested using python3)