### PR TITLE
[StompAMQ]Initialize the body to None

### DIFF
--- a/src/python/CMSMonitoring/StompAMQ.py
+++ b/src/python/CMSMonitoring/StompAMQ.py
@@ -326,6 +326,7 @@ class StompAMQ(object):
         :return: The notification body in case of failure, or else None
         """
         failedNotification = None
+        body = None
         try:
             body = notification.pop('body')
             conn.send(destination=self._topic,
@@ -336,7 +337,7 @@ class StompAMQ(object):
         except Exception as exc:
             self.logger.error('Notification: %s (type=%s) not send, error: %s', \
                     str(notification), type(notification), str(exc))
-            failedNotification = body
+            failedNotification = body or {}
         return failedNotification
 
     def make_notification(self, payload, docType, docId=None, \


### PR DESCRIPTION
To prevent the "used before assignment" exception in the exception management.