### PR TITLE
Fixed ssb_alerting.go

### DIFF
--- a/src/go/MONIT/ssb_alerting.go
+++ b/src/go/MONIT/ssb_alerting.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -29,6 +30,12 @@ var tag string
 //verbose defines verbosity level
 var verbose int
 
+//MAX timeStamp //Saturday, May 24, 3000 3:43:26 PM
+var maxtstmp int64 = 32516091806
+
+//Map for storing Existing SSB Data
+var exstSSBData map[string]int
+
 //CERN SSB Data Struct
 type ssb struct {
 	Results []struct {
@@ -49,22 +56,27 @@ type amJSON struct {
 		Tag       string `json:"tag"`
 	} `json:"labels"`
 	Annotations struct {
-		Date             string `json:"date"`
-		Description      string `json:"description"`
-		FeName           string `json:"feName"`
-		MonitState       string `json:"monitState"`
-		MonitState1      string `json:"monitState1"`
-		SeName           string `json:"seName"`
-		ShortDescription string `json:"shortDescription"`
-		SsbNumber        string `json:"ssbNumber"`
-		SysCreatedBy     string `json:"sysCreatedBy"`
-		SysModCount      string `json:"sysModCount"`
-		SysUpdatedBy     string `json:"sysUpdatedBy"`
-		Type             string `json:"type"`
-		UpdateTimestamp  string `json:"updateTimestamp"`
+		Date             string    `json:"date"`
+		Description      string    `json:"description"`
+		FeName           string    `json:"feName"`
+		MonitState       string    `json:"monitState"`
+		MonitState1      string    `json:"monitState1"`
+		SeName           string    `json:"seName"`
+		ShortDescription string    `json:"shortDescription"`
+		SsbNumber        string    `json:"ssbNumber"`
+		SysCreatedBy     string    `json:"sysCreatedBy"`
+		SysModCount      string    `json:"sysModCount"`
+		SysUpdatedBy     string    `json:"sysUpdatedBy"`
+		Type             string    `json:"type"`
+		UpdateTimestamp  time.Time `json:"updateTimestamp"`
 	} `json:"annotations"`
-	StartsAt string `json:"startsAt"`
-	EndsAt   string `json:"endsAt"`
+	StartsAt time.Time `json:"startsAt"`
+	EndsAt   time.Time `json:"endsAt"`
+}
+
+//AlertManager GET API acceptable JSON Data struct for SSB data
+type ssbData struct {
+	Data []amJSON
 }
 
 //function for parsing JSON data from CERN SSB Data
@@ -97,42 +109,64 @@ func fetchJSON(filename string) []byte {
 
 }
 
+//function for eliminating "none" or empty values ("null") in JSON
+func nullValueChecker(target *string, data interface{}) {
+
+	if b, ok := data.(string); ok {
+		*target = b
+	}
+}
+
 //function for converting SSB JSON Data into JSON Data required by AlertManager APIs.
 func (data *ssb) convertData() []byte {
 
-	var temp amJSON
 	var finalData []amJSON
+	exstSSBData = make(map[string]int)
 
 	for _, each := range data.Results[0].Series[0].Values {
+		var temp amJSON
+		var _beginTS, _endTS, _updateTS time.Time
+		var ssbNum string
+		nullValueChecker(&ssbNum, each[10])
 
-		begin := int64(each[1].(float64))
-		end := int64(each[4].(float64))
-		updatets := int64(each[15].(float64))
+		exstSSBData[ssbNum] = 1
 
-		_beginRFC3339 := time.Unix(0, begin*int64(time.Millisecond)).UTC().Format(time.RFC3339)
-		_endRFC3339 := time.Unix(0, end*int64(time.Millisecond)).UTC().Format(time.RFC3339)
-		_updatetsRFC3339 := time.Unix(0, updatets*int64(time.Millisecond)).UTC().Format(time.RFC3339)
+		if b, ok := each[1].(float64); ok {
+			_beginTS = time.Unix(0, int64(b)*int64(time.Millisecond)).UTC()
+		}
 
-		temp.Labels.Alertname = each[2].(string)
+		if e, ok := each[4].(float64); ok {
+			_endTS = time.Unix(0, int64(e)*int64(time.Millisecond)).UTC()
+
+		} else {
+			_endTS = time.Unix(maxtstmp, 0).UTC() // If not given EndTime the alert will be open ending. Max TimeStamp value given.
+		}
+
+		if u, ok := each[15].(float64); ok {
+			_updateTS = time.Unix(0, int64(u)*int64(time.Millisecond)).UTC()
+		}
+
+		temp.Labels.Alertname = "ssb-" + ssbNum //ssbNumber as an unique key for alertname
 		temp.Labels.Severity = severity
 		temp.Labels.Tag = tag
 
-		temp.Annotations.Date = each[0].(string)
-		temp.Annotations.Description = each[2].(string)
-		temp.Annotations.FeName = each[5].(string)
-		temp.Annotations.MonitState = each[6].(string)
-		temp.Annotations.MonitState1 = each[7].(string)
-		temp.Annotations.SeName = each[8].(string)
-		temp.Annotations.ShortDescription = each[9].(string)
-		temp.Annotations.SsbNumber = each[10].(string)
-		temp.Annotations.SysCreatedBy = each[11].(string)
-		temp.Annotations.SysModCount = each[12].(string)
-		temp.Annotations.SysUpdatedBy = each[13].(string)
-		temp.Annotations.Type = each[14].(string)
-		temp.Annotations.UpdateTimestamp = _updatetsRFC3339
+		nullValueChecker(&temp.Annotations.Date, each[0])
+		nullValueChecker(&temp.Annotations.Description, each[2])
+		nullValueChecker(&temp.Annotations.FeName, each[5])
+		nullValueChecker(&temp.Annotations.MonitState, each[6])
+		nullValueChecker(&temp.Annotations.MonitState1, each[7])
+		nullValueChecker(&temp.Annotations.SeName, each[8])
+		nullValueChecker(&temp.Annotations.ShortDescription, each[9])
+		nullValueChecker(&temp.Annotations.SsbNumber, each[10])
+		nullValueChecker(&temp.Annotations.SysCreatedBy, each[11])
+		nullValueChecker(&temp.Annotations.SysModCount, each[12])
+		nullValueChecker(&temp.Annotations.SysUpdatedBy, each[13])
+		nullValueChecker(&temp.Annotations.Type, each[14])
 
-		temp.StartsAt = _beginRFC3339
-		temp.EndsAt = _endRFC3339
+		temp.Annotations.UpdateTimestamp = _updateTS
+
+		temp.StartsAt = _beginTS
+		temp.EndsAt = _endTS
 
 		finalData = append(finalData, temp)
 
@@ -145,6 +179,57 @@ func (data *ssb) convertData() []byte {
 	}
 
 	return jsonStr
+
+}
+
+//function for get request on /api/v1/alerts alertmanager endpoint for fetching alerts.
+func get() *ssbData {
+
+	var data *ssbData
+
+	//GET API for fetching only GGUS alerts.
+	apiurl := alertManagerURL + "/api/v1/alerts?active=true&silenced=false&inhibited=false&unprocessed=false&filter=tag=\"SSB\""
+
+	req, err := http.NewRequest("GET", apiurl, nil)
+	req.Header.Add("Accept-Encoding", "identity")
+	req.Header.Add("Accept", "application/json")
+
+	client := &http.Client{}
+
+	if verbose > 1 {
+		dump, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			log.Println("Request: ", string(dump))
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	byteValue, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		log.Printf("Unable to read JSON Data from AlertManager GET API, error: %v\n", err)
+		return data
+	}
+
+	err = json.Unmarshal(byteValue, &data)
+	if err != nil {
+		log.Printf("Unable to parse JSON Data from AlertManager GET API, error: %v\n", err)
+		return data
+	}
+
+	if verbose > 1 {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Println("Response: ", string(dump))
+		}
+	}
+
+	return data
 
 }
 
@@ -178,6 +263,61 @@ func post(jsonStr []byte) {
 	}
 }
 
+//Function to end alerts for SSB data which had no EndTime and now they are resolved.
+func deleteAlerts() {
+	amData := get()
+	var finalData []amJSON
+
+	for _, each := range amData.Data {
+		var temp amJSON
+
+		// If SSB Data which are in Existing SSB Data Map then no need to send End Time, We Skip.
+		if exstSSBData[each.Annotations.SsbNumber] == 1 {
+			continue
+		}
+
+		temp.Labels.Alertname = each.Labels.Alertname
+		temp.Labels.Severity = each.Labels.Severity
+		temp.Labels.Tag = each.Labels.Tag
+
+		temp.Annotations.Date = each.Annotations.Date
+		temp.Annotations.Description = each.Annotations.Description
+		temp.Annotations.FeName = each.Annotations.FeName
+		temp.Annotations.MonitState = each.Annotations.MonitState
+		temp.Annotations.MonitState1 = each.Annotations.MonitState1
+		temp.Annotations.SeName = each.Annotations.SeName
+		temp.Annotations.ShortDescription = each.Annotations.ShortDescription
+		temp.Annotations.SsbNumber = each.Annotations.SsbNumber
+		temp.Annotations.SysCreatedBy = each.Annotations.SysCreatedBy
+		temp.Annotations.SysModCount = each.Annotations.SysModCount
+		temp.Annotations.SysUpdatedBy = each.Annotations.SysUpdatedBy
+		temp.Annotations.Type = each.Annotations.Type
+		temp.Annotations.UpdateTimestamp = each.Annotations.UpdateTimestamp
+
+		temp.StartsAt = each.StartsAt
+		temp.EndsAt = time.Now().UTC()
+
+		//Checking if Start Time is Afer Time Right now, maybe false alert added by mistake. **Corner Case to be handled**
+		if each.StartsAt.Before(temp.EndsAt) == false {
+			temp.StartsAt = time.Now().UTC()
+			temp.EndsAt = time.Now().UTC()
+		}
+
+		finalData = append(finalData, temp)
+	}
+
+	jsonStr, err := json.Marshal(finalData)
+	if err != nil {
+		log.Printf("Unable to convert JSON Data, error: %v\n", err)
+	}
+
+	if verbose > 1 {
+		fmt.Println("Deleted Alerts: ", string(jsonStr))
+	}
+
+	post(jsonStr)
+}
+
 //function containing all logics for alerting.
 func alert(inp string) {
 
@@ -186,6 +326,7 @@ func alert(inp string) {
 	data.parseJSON(jsonData)
 	jsonStrAM := data.convertData() //JSON data in AlertManager APIs format.
 	post(jsonStrAM)
+	deleteAlerts()
 
 }
 


### PR DESCRIPTION
Fixed :-

- `panic: interface conversion: interface {} is nil, not float64`
- Addition of cycle checking for alerts which have no End Time ( similar to GGUS alerts )
- Addition of checks for all possible variables.
- Addition of check for Start Time > EndTime ( may be a possibility - when an alert dated Nov 2020 is added and deleted afterwards then StartTime becomes greater than time.Now() )