### PR TITLE
Int Module - Addition of multiple dashboard annotation based on specific set of keywords

### DIFF
--- a/src/go/intelligence/int_test/test_cases.json
+++ b/src/go/intelligence/int_test/test_cases.json
@@ -48,7 +48,7 @@
       "monitState": "CLOSED",
       "monitState1": "CLOSED",
       "seName": "Database Service",
-      "shortDescription": "Database Intervention in building 7777 - TEST ALERT",
+      "shortDescription": "Database update in building 7777 - TEST ALERT",
       "ssbNumber": "OTG00099",
       "sysCreatedBy": "jdoe2",
       "sysModCount": "22",

--- a/src/go/intelligence/int_test/test_config.json
+++ b/src/go/intelligence/int_test/test_config.json
@@ -22,7 +22,7 @@
     "url" : "https://monit-grafana.cern.ch",
     "dashboardSearchAPI" : "/api/search",
     "annotationAPI" : "/api/annotations",
-    "tags" : ["cmsweb-play"],
+    "tags" : ["cmsweb-play","cmsweb-play2"],
     "token" : "<YOUR-GRAFANA-PROXY-TOKEN>",
     "dashboardsCacheExpiration" : 1 
   },
@@ -66,8 +66,19 @@
       },
       "annotationMap": {
         "label": "shortDescription",
-        "actions": ["intervention", "outage"],
-        "systems": ["network", "database", "db"],
+        "annotations": [
+          {
+            "actions": ["intervention", "outage"],
+            "systems": ["network", "database", "db"],
+            "tags": ["cmsweb-play"]
+          },
+
+          {
+            "actions": ["update", "upgrade"],
+            "systems": ["network", "database", "db"],
+            "tags": ["cmsweb-play2"]
+          }
+        ],
         "urlLabel": "URL"
       }
     },
@@ -83,8 +94,13 @@
       },
       "annotationMap": {
         "label": "Subject",
-        "actions": ["transfers", "outage"],
-        "systems": ["rucio"],
+        "annotations": [
+          {
+            "actions": ["transfer", "outage"],
+            "systems": ["rucio"],
+            "tags": ["cmsweb-play2"]
+          }
+        ],
         "urlLabel": "URL"
       }
     }

--- a/src/go/intelligence/models/models.go
+++ b/src/go/intelligence/models/models.go
@@ -48,7 +48,7 @@ type AllSilences struct {
 }
 
 //AllDashboardsFetched is an array of all Dashboards' information having given tags in common
-type AllDashboardsFetched []struct {
+type AllDashboardsFetched struct {
 	ID          float64  `json:"id"`
 	UID         string   `json:"uid"`
 	Title       string   `json:"title"`
@@ -121,11 +121,17 @@ type silence struct {
 	SilenceStatus []string `json:"silenceStatus"` //Labels for status of the silence
 }
 
+//annotations struct for storing specific set of keywords & set of dashboards to annotate when these keywords are matched in alerts.
+type annotationsData struct {
+	Actions []string `json:"actions"`
+	Systems []string `json:"systems"`
+	Tags    []string `json:"tags"`
+}
+
 type annotationMap struct {
-	Label    string   `json:"label"`
-	Actions  []string `json:"actions"`
-	Systems  []string `json:"systems"`
-	URLLabel string   `json:"urlLabel"`
+	Label           string            `json:"label"`
+	AnnotationsData []annotationsData `json:"annotations"`
+	URLLabel        string            `json:"urlLabel"`
 }
 
 //Service data struct

--- a/src/go/intelligence/models/models.go
+++ b/src/go/intelligence/models/models.go
@@ -49,28 +49,28 @@ type AllSilences struct {
 
 //AllDashboardsFetched is an array of all Dashboards' information having given tags in common
 type AllDashboardsFetched struct {
-	ID          float64  `json:"id"`
-	UID         string   `json:"uid"`
-	Title       string   `json:"title"`
-	URI         string   `json:"uri"`
-	URL         string   `json:"url"`
-	Slug        string   `json:"slug"`
-	Type        string   `json:"type"`
-	Tags        []string `json:"tags"`
-	IsStarred   bool     `json:"isStarred"`
-	FolderID    float64  `json:"folderId"`
-	FolderUID   string   `json:"folderUid"`
-	FolderTitle string   `json:"folderTitle"`
-	FolderURL   string   `json:"folderUrl"`
+	ID          float64  `json:"id"`          //ID for the dashboard
+	UID         string   `json:"uid"`         //UID for the dashboard
+	Title       string   `json:"title"`       //Title for the dashboard
+	URI         string   `json:"uri"`         //URI of the dashboard
+	URL         string   `json:"url"`         //URL of the dashboard
+	Slug        string   `json:"slug"`        //Slug of the dashboard
+	Type        string   `json:"type"`        //Type of the dashboard
+	Tags        []string `json:"tags"`        //All tags for the dashboard	(eg. prod, jobs, cmsweb etc.)
+	IsStarred   bool     `json:"isStarred"`   //if dashboard is starred
+	FolderID    float64  `json:"folderId"`    //ID for the folder
+	FolderUID   string   `json:"folderUid"`   //UID for the folder
+	FolderTitle string   `json:"folderTitle"` //Title of the folder
+	FolderURL   string   `json:"folderUrl"`   //URL of the folder
 }
 
 //GrafanaDashboard data struct for storing Annotation's information to each dashboard
 type GrafanaDashboard struct {
-	DashboardID float64  `json:"dashboardId"`
-	Time        int64    `json:"time"`
-	TimeEnd     int64    `json:"timeEnd"`
-	Tags        []string `json:"tags"`
-	Text        string   `json:"text"`
+	DashboardID float64  `json:"dashboardId"` // ID of a dashboard
+	Time        int64    `json:"time"`        //Start Time of the annotation
+	TimeEnd     int64    `json:"timeEnd"`     //End Time of the annotation
+	Tags        []string `json:"tags"`        //Dashboard tags to be annotated (eg. prod, jobs, cmsweb etc.)
+	Text        string   `json:"text"`        //Annotation Text Field
 }
 
 //TestingData data struct
@@ -123,15 +123,15 @@ type silence struct {
 
 //annotations struct for storing specific set of keywords & set of dashboards to annotate when these keywords are matched in alerts.
 type annotationsData struct {
-	Actions []string `json:"actions"`
-	Systems []string `json:"systems"`
-	Tags    []string `json:"tags"`
+	Actions []string `json:"actions"` //A set of keywords of actions taken (eg. outage, intervention, update, upgrade, down etc.)
+	Systems []string `json:"systems"` //A set of keywords of systems affected (eg. network, database, rucio etc.)
+	Tags    []string `json:"tags"`    //A list of tags of dashboards in Grafana
 }
 
 type annotationMap struct {
-	Label           string            `json:"label"`
-	AnnotationsData []annotationsData `json:"annotations"`
-	URLLabel        string            `json:"urlLabel"`
+	Label           string            `json:"label"`       //Unique field of the alert Data where descriptive information about it is given so that keywords are matched in here (eg. for SSB --> "shortDescription", for GGUS --> "Subject" etc.)
+	AnnotationsData []annotationsData `json:"annotations"` //annotationsData struct
+	URLLabel        string            `json:"urlLabel"`    //Field which identifies URL in the alert data (eg. "URL" has been set for both GGUS & SSB).
 }
 
 //Service data struct

--- a/src/go/intelligence/pipeline/add_annotations.go
+++ b/src/go/intelligence/pipeline/add_annotations.go
@@ -53,7 +53,12 @@ func AddAnnotation(data <-chan models.AmJSON) <-chan models.AmJSON {
 						for _, dashboard := range utils.DCache.Dashboards {
 
 							/*
-								getTagsIntersection(annotationDashboardTags, allDashboardsTags []string) bool {} is used for finding intersection between two list of strings each having tags for Grafana Dashboards.
+								ifTagsIntersect(annotationDashboardTags, allDashboardsTags []string) bool {..} is used for checking if there's intersection between two list of strings each having tags for Grafana Dashboards.
+
+								Check is done by finding the length of intersection result.
+
+								If it is greater than 0 --> Means there are some tags after intersection.
+								Else --> there are no tags after intersection
 
 								Each service has annotationMap field, and annotationMap has a "annotation" field which is a list of action & system keywords and tags for dashboards.
 								See below in the example.
@@ -93,12 +98,11 @@ func AddAnnotation(data <-chan models.AmJSON) <-chan models.AmJSON {
 
 										Using example above we can say the intersection result would be,
 
-										["cmsweb-play"] ---> #
-										["das"]			---> *
-
+										["cmsweb-play"] ---> #	since len(["cmsweb-play"]) > 0 returns true
+										["das"]			---> *	since len(["cmsweb-play"]) > 0 returns true
 							*/
 
-							ifCommonTagsFound := getTagsIntersection(annotationData.Tags, dashboard.Tags)
+							ifCommonTagsFound := ifTagsIntersect(annotationData.Tags, dashboard.Tags)
 
 							if ifCommonTagsFound == false {
 								continue
@@ -141,8 +145,8 @@ func makeHTMLhref(url string) string {
 	return "<a target=_blank href=" + url + ">URL</a>"
 }
 
-//getTagsIntersection for finding intersection between two list of dashboard tags.
-func getTagsIntersection(annotationDashboardTags, allDashboardsTags []string) bool {
+//ifTagsIntersect for checking intersection between two list of dashboard tags.
+func ifTagsIntersect(annotationDashboardTags, allDashboardsTags []string) bool {
 
 	var intersectionResult []string
 


### PR DESCRIPTION
Changes :-

- Change in the config file which now supports annotations based on a different set of keywords to dashboards with a different tag. The list of annotations can be easily configured with a specific set of keywords for specific dashboards identified by tags.
```
"annotationMap": {
        "label": "shortDescription",
        "annotations": [
          {
            "actions": ["intervention", "outage"],
            "systems": ["network", "database", "db"],
            "tags": ["cmsweb-play"]
          },

          {
            "actions": ["update", "upgrade"],
            "systems": ["network", "database", "db"],
            "tags": ["cmsweb-play2"]
          }
        ],
        "urlLabel": "URL"
      }
```
- Change in the add_annotation component of the pipeline, where the intersection between the dashboards is found and accordingly they are annotated.