### PR TITLE
Bug fix annotationManager.go

### DIFF
--- a/src/go/MONIT/annotationManager.go
+++ b/src/go/MONIT/annotationManager.go
@@ -355,7 +355,7 @@ func tabulate(data []annotationData) {
 
 	for _, each := range data {
 
-		fmt.Fprintf(w, " %d\t%d\t%s\t%s\t%s",
+		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s",
 			each.ID,
 			each.DashboardID,
 			strings.Split(each.Text, "\n<a")[0],


### PR DESCRIPTION
fyi @vkuznet 
Bug definition: ID and DASID are concatenated without a space or a tab.
Solution: Removing space in the formatting string is solved the problem