### PR TITLE
Fix ggus_alerting parameter

### DIFF
--- a/scripts/ggus_alert.sh
+++ b/scripts/ggus_alert.sh
@@ -37,7 +37,7 @@ verbose=${7:-0}
 while true;  do
     echo "### ggus_parser -format $ggus_format -out $data_file -timeout $timeout -verbose $verbose"
     ggus_parser -format $ggus_format -out $data_file -timeout $timeout -verbose $verbose
-    echo "### ggus_alerting -input $data_file -url $cmsmon_url -vo $vo -verbose $verbose"
-    ggus_alerting -input $data_file -url $cmsmon_url -vo $vo -verbose $verbose
+    echo "### ggus_alerting -input $data_file -urls $cmsmon_url -vo $vo -verbose $verbose"
+    ggus_alerting -input $data_file -urls $cmsmon_url -vo $vo -verbose $verbose
     sleep $interval
 done


### PR DESCRIPTION
Fix ggus_alerting script parameter.

- I updated `robot-secrets` and `proxy-secrets` in alerts namespace in cmsmonit-new and ha1 (there were old certs, cronjobs also recreated). 
- `proxy-account` ServiceAccount is created in ha1: k apply -f crons/proxy-account.yaml -n alerts
- After this PR, ggus parser will be fixed.
- As a last step, cmsmonit-intelligence pod will be fixed (it fails sometimes), I'm debugging it.
- Yes, I'll improve documentation (adding to my long documentation to-do list :) )