### PR TITLE
Fix gh workflow

### DIFF
--- a/.github/workflows/build-go-tools.yml
+++ b/.github/workflows/build-go-tools.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - 'go-*.*.*'
+    paths-ignore:
+      - 'src/go/rucio-dataset-mon-go/**'
 
 jobs:
   build:

--- a/.github/workflows/build-rucio-mon.yml
+++ b/.github/workflows/build-rucio-mon.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'go-*.*.*'
     paths:
-      - src/go/rucio-dataset-mon-go/**
+      - 'src/go/rucio-dataset-mon-go/**'
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
           password: ${{ secrets.CERN_TOKEN }}
 
       - name: Publish cmsmon-rucio-ds-web image to registry.cern.ch
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.CERN_LOGIN }}
           password: ${{ secrets.CERN_TOKEN }}


### PR DESCRIPTION
We're not ready to use `build-push-action@v3` version, since we're fetching Dockerfile from remote and apply `sed` on it. `@v3` we can provide `file` option along with `build-args` and we can modify our Dockerfiles to use build args, but I could not find how to wget Dockerfile from other git repo in [@v3 docs](https://github.com/docker/build-push-action). Anyway, I'm switching to `@v1`.