### PR TITLE
Add send and receive hearbeat params to stomp

### DIFF
--- a/src/python/CMSMonitoring/StompAMQ7.py
+++ b/src/python/CMSMonitoring/StompAMQ7.py
@@ -160,6 +160,8 @@ class StompAMQ7(object):
     :param loglevel: logging level, default is logging.WARNING
     :param timeout_interval: provides timeout interval to failed broker
     :param ipv4_only: use ipv4 servers only
+    :param send_timeout: heartbeat send timeout in milliseconds
+    :param recv_timeout: heartbeat receive timeout in milliseconds
     """
 
     # Version number is to be added in header
@@ -177,7 +179,9 @@ class StompAMQ7(object):
                  key=None,
                  loglevel=logging.WARNING,
                  timeout_interval=600,
-                 ipv4_only=True):
+                 ipv4_only=True,
+                 send_timeout=4000,
+                 recv_timeout=4000):
         # Set logger
         logging.basicConfig(format="%(asctime)s.%(msecs)03dZ [%(levelname)s] %(filename)s:%(lineno)d %(message)s ",
                             datefmt="%Y-%m-%dT%H:%M:%S",
@@ -217,7 +221,7 @@ class StompAMQ7(object):
             for idx in range(len(self.ip_and_ports)):
                 host_and_ports = [self.ip_and_ports[idx]]
                 try:
-                    conn = stomp.Connection(host_and_ports=host_and_ports)
+                    conn = stomp.Connection(host_and_ports=host_and_ports, heartbeats=(send_timeout, recv_timeout))
                     desc = f"host: {host_and_ports}"
                     if self._use_ssl:
                         conn.set_ssl(for_hosts=host_and_ports, key_file=self._key, cert_file=self._cert)
@@ -230,7 +234,7 @@ class StompAMQ7(object):
                     self.logger.warning(msg)
         else:
             try:
-                conn = stomp.Connection(host_and_ports=self._host_and_ports)
+                conn = stomp.Connection(host_and_ports=self._host_and_ports, heartbeats=(send_timeout, recv_timeout))
                 desc = f"host: {self._host_and_ports}"
                 if self._use_ssl:
                     conn.set_ssl(for_hosts=self._host_and_ports, key_file=self._key, cert_file=self._cert)


### PR DESCRIPTION
As suggested by the messaging team, heartbeat[1] is implemented in `StompAMQ7` module. Instead of using tuple, I make this setting compatible with its Go version[2] and use `send_timeout, recv_timeout` parameters. Default heartbeat timeouts are `4000ms` for recv and send.

New release is published from this commit: https://pypi.org/project/CMSMonitoring/0.6.5/

Example run:
`pip install CMSMonitoring==0.6.5`
```
from CMSMonitoring.StompAMQ7 import StompAMQ7
stompSvc = StompAMQ7(username=username, password=password, producer=producer, topic=topic, key=ckey, cert=cert, validation_schema=None, host_and_ports=[(host, port)], send_timeout=4000, recv_timeout=4000)
messages = []

doc = {"wmbs_status": "ceyhun_4", "type": "test_ceyhun", "num_jobs":0, "agent_url": "test_ceyhun_4"}
notif, _, _ = stompSvc.make_notification(payload=doc, doc_type=doc_type, ts=int(time.time()), data_subfield="payload")
messages.append(notif)

stompSvc.send(messages)
```

[1] https://jasonrbriggs.github.io/stomp.py/api.html#dealing-with-disconnects
[2] https://github.com/vkuznet/lb-stomp/blob/master/stomp.go#L27