### PR TITLE
Avoid overwritting logger object in StompAMQ modules

### DIFF
--- a/src/python/CMSMonitoring/StompAMQ.py
+++ b/src/python/CMSMonitoring/StompAMQ.py
@@ -69,8 +69,11 @@ class StompyListener(object):
     connection.
     """
     def __init__(self, logger=None):
-        logging.basicConfig(level=logging.debug)
-        self.logger = logger if logger else logging.getLogger('StompyListener')
+        if logger:
+            self.logger = logger
+        else:
+            logging.basicConfig(level=logging.debug)
+            self.logger = logging.getLogger('StompyListener')
 
     def safe_headers(self, headers):
         "Return stripped headers"
@@ -168,8 +171,11 @@ class StompAMQ(object):
         self._password = password
         self._producer = producer
         self._topic = topic
-        logging.basicConfig(level=validation_loglevel)
-        self.logger = logger if logger else logging.getLogger('StompAMQ')
+        if logger:
+            self.logger = logger
+        else:
+            logging.basicConfig(level=validation_loglevel)
+            self.logger = logging.getLogger('StompAMQ')
         self._host_and_ports = host_and_ports or [('cms-test-mb.cern.ch', 61313)]
         self.ip_and_ports = []
         try:

--- a/src/python/CMSMonitoring/StompAMQ7.py
+++ b/src/python/CMSMonitoring/StompAMQ7.py
@@ -74,9 +74,12 @@ class StompyListener(stomp.ConnectionListener):
     """Auxiliary listener class to fetch all possible states in the Stomp connection."""
 
     def __init__(self, logger=None):
-        logging.basicConfig(format='%(asctime)s- StompAMQ:%(levelname)s-%(message)s', datefmt='%Y-%m-%dT%H:%M:%S.%f%z',
-                            level=logging.WARNING)
-        self.logger = logger if logger else logging.getLogger('StompyListener')
+        if logger:
+            self.logger = logger
+        else:
+            logging.basicConfig(format='%(asctime)s- StompAMQ:%(levelname)s-%(message)s', datefmt='%Y-%m-%dT%H:%M:%S.%f%z',
+                                level=logging.WARNING)
+            self.logger = logging.getLogger('StompyListener')
 
     @staticmethod
     def safe_headers(headers):
@@ -182,12 +185,15 @@ class StompAMQ7(object):
                  ipv4_only=True,
                  send_timeout=4000,
                  recv_timeout=4000):
-        # Set logger
-        logging.basicConfig(format="%(asctime)s.%(msecs)03dZ [%(levelname)s] %(filename)s:%(lineno)d %(message)s ",
-                            datefmt="%Y-%m-%dT%H:%M:%S",
-                            level=loglevel)
-        logging.Formatter.converter = gmtime
-        self.logger = logger if logger else logging.getLogger('StompAMQ')
+        if logger:
+            self.logger = logger
+        else:
+            # Set logger
+            logging.basicConfig(format="%(asctime)s.%(msecs)03dZ [%(levelname)s] %(filename)s:%(lineno)d %(message)s ",
+                                datefmt="%Y-%m-%dT%H:%M:%S",
+                                level=loglevel)
+            logging.Formatter.converter = gmtime
+            self.logger = logging.getLogger('StompAMQ')
 
         self._username, self._password, self._producer, self._topic = username, password, producer, topic
         self._host_and_ports = host_and_ports or [('cms-test-mb.cern.ch', 61323)]


### PR DESCRIPTION
Fixes #160 

Check if a logger object has been passed over to StompAMQ modules before making any changes to it. If one already exists, use it as is without changing the format of the log records.

@mrceyhun could you please review and release this PR. If everything looks fine, I would need a new tag with these changes in.