### PR TITLE
Increase page length limit

### DIFF
--- a/src/go/rucio-dataset-monitoring/static/templates/datasets.tmpl
+++ b/src/go/rucio-dataset-monitoring/static/templates/datasets.tmpl
@@ -343,8 +343,8 @@
             // stateSaveParams: function (setting, data){
             // },
             aLengthMenu: [
-                [5, 10, 25, 50, 100],
-                [5, 10, 25, 50, 100]
+                [5, 10, 25, 50, 100, 500, 1000, 10000],
+                [5, 10, 25, 50, 100, 500, 1000, 10000]
             ],
             ajax: {
                 url: "../api/datasets",

--- a/src/go/rucio-dataset-monitoring/static/templates/detailed_datasets.tmpl
+++ b/src/go/rucio-dataset-monitoring/static/templates/detailed_datasets.tmpl
@@ -200,8 +200,8 @@
             dom: "lirtpB", // no main search ("f"), just individual column search
             language: {processing: '<i class="fa fa-spinner fa-spin fa-3x fa-fw"></i><span class="sr-only">Loading...</span> '},
             aLengthMenu: [
-                [5, 10, 25, 50, 100],
-                [5, 10, 25, 50, 100]
+                [5, 10, 25, 50, 100, 500, 1000, 10000],
+                [5, 10, 25, 50, 100, 500, 1000, 10000]
             ],
             ajax: {
                 url: "../api/rse-details",


### PR DESCRIPTION
As requested by our users, new page length options are added `500, 1000, 10000` for "RUCIO DATASETS MONITORING" in http://cmsweb-test1.cern.ch:31280/ . So, max page length option will be `10000`.