### PR TITLE
Move cmsmonitoringbackup Kubernetes cluster

### DIFF
--- a/grafana-backup/README.md
+++ b/grafana-backup/README.md
@@ -1,0 +1,35 @@
+## Grafana backup
+Gets json definitions of all CMSMonitoring related dashboards using Grafana API.
+
+Then compresses and puts them to HDFS folder under `/cms/backups/grafana/` and EOS folder `/eos/cms/store/group/offcomp_monit/`.
+
+
+## Requirements
+- Create file to your Grafana authentication token and name it `keys.json`
+
+```
+    {
+        "SECRET_KEY": "YOUR_SECRET_KEY"
+    }
+```
+
+- Get `amtool` executable
+```
+curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.23.0/alertmanager-0.23.0.linux-amd64.tar.gz && \
+tar xfz alertmanager-0.23.0.linux-amd64.tar.gz && \
+mv alertmanager-0.23.0.linux-amd64/amtool . && \
+rm -rf alertmanager-0.23.0.linux-amd64*
+```
+
+## How to use
+
+- Run the file:
+```sh
+python3 dashboard-exporter.py --token keys.json --hdfs-path /path/to/h_backup/ --filesystem-path /path/to/fs_backup/
+```
+- Set file executable:
+```sh
+chmod +x ./dashboard-exporter.py
+```
+- Set crontab for preferred timeframe
+- See `run.sh` file

--- a/grafana-backup/dashboard-exporter.py
+++ b/grafana-backup/dashboard-exporter.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import sys
+import json
+import time
+import shutil
+import tarfile
+import requests
+import subprocess
+import click
+
+baseUrl = 'https://monit-grafana.cern.ch/api'
+
+def updatePathEnding(path):
+    if not path.endswith("/"):
+        path += "/"
+    return path
+def getGrafanaAuth(fname):
+    if not os.path.exists(fname):
+        print("File {} does not exist".format(fname))
+        sys.exit(1)
+    with open(fname, 'r+') as keyFile:
+        SECRET_KEY = json.load(keyFile).get('SECRET_KEY')
+    headers = {"Authorization": "Bearer %s" % SECRET_KEY}
+    return headers
+
+
+def createBackUpFiles(dashboard, folderTitle, headers):
+    allJson = []
+
+    dashboardUid = dashboard.get('uid')
+    path = "grafana/dashboards/%s" % folderTitle
+
+    if not os.path.exists(path):
+        try:
+            os.makedirs(os.path.join('grafana', 'dashboards', folderTitle))
+            print("Successfully created the directory %s " % path)
+        except OSError:
+            print("Creation of the directory %s failed" % path)
+    dashboardUrl = '%s/dashboards/uid/%s' % (baseUrl, dashboardUid)
+    print('dashboardUrl', dashboardUrl)
+    req = requests.get(dashboardUrl, headers=headers)
+    dashboardData = req.json().get('dashboard')
+
+    # Replace characters that might cause harm
+    titleOfDashboard = dashboardData.get('title').replace(" ", "").replace(".", "_").replace("/", "_")
+    uidOfDashboard = dashboardData.get('uid')
+
+    filenameForFolder = '%s/%s-%s.json' % (path, titleOfDashboard, uidOfDashboard)
+    print('filenameForFolder', filenameForFolder)
+    with open(filenameForFolder, "w+") as jsonFile:
+        json.dump(dashboardData, jsonFile)
+    print('*' * 10 + '\n')
+    allJson.append(dashboardData)
+
+    filenameForAllJson = '%s/all.json' % path
+    print('filenameForAllJson', filenameForAllJson)
+    with open(filenameForAllJson, "w+") as jsonFile:
+        json.dump(allJson, jsonFile)
+
+
+def searchFoldersFromGrafana(headers):
+    foldersUrl = 'https://monit-grafana.cern.ch/api/search?folderIds=0&orgId=11'
+
+    req = requests.get(foldersUrl, headers=headers)
+    if req.status_code != 200:
+        print("Request {}, failed with reason: {}".format(foldersUrl, req.reason))
+        sys.exit(1)
+    foldersJson = req.json()
+
+    for folder in foldersJson:
+        folderId = folder.get('id')
+        folderTitle = folder.get('title')
+
+        if folderTitle not in ['Production', 'Development', 'Playground', 'Backup']:
+            folderTitle = 'General'
+            dashboard = folder
+            createBackUpFiles(dashboard, folderTitle, headers)
+
+        else:
+            dashboardQuery = 'search?folderIds=%s&orgId=11&query=' % folderId
+            dashboardQueryUrl = '%s/%s' % (baseUrl, dashboardQuery)
+
+            print('individualFolderUrl', dashboardQueryUrl)
+
+            req = requests.get(dashboardQueryUrl, headers=headers)
+            folderData = req.json()
+
+            pathToDb = os.path.abspath("grafana")
+            if not os.path.exists(pathToDb):
+                os.makedirs(pathToDb)
+
+            filenameForFolder = 'grafana/%s-%s.json' % (folderId, folderTitle)
+            with open(filenameForFolder, "w+") as jsonFile:
+                json.dump(folderData, jsonFile)
+
+            dashboardsAmount = len(folderData)
+            for index, dashboard in enumerate(folderData):
+                folderTitle = dashboard.get('folderTitle')
+                print('Index/Amount: %s/%s' % (index, dashboardsAmount))
+
+                createBackUpFiles(dashboard, folderTitle, headers)
+
+
+def createTar(path, tar_name):
+    with tarfile.open(tar_name, "w:gz") as tar_handle:
+        for root, _, files in os.walk(path):
+            for file in files:
+                tar_handle.add(os.path.join(root, file))
+
+
+def removeTempFiles(path):
+    for root, dirs, files in os.walk(path):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))
+    if os.path.exists(path):
+        os.rmdir(path)
+
+
+def get_date():
+    gmt = time.gmtime()
+    year = str(gmt.tm_year)
+    mon = gmt.tm_mon
+    if len(str(mon)) == 1:
+        mon = '0{}'.format(mon)
+    else:
+        mon = str(mon)
+    day = gmt.tm_mday
+    if len(str(day)) == 1:
+        day = '0{}'.format(day)
+    else:
+        day = str(day)
+    return day, mon, year
+
+
+def copyToHDFS(archive, hdfs_path):
+    day, mon, year = get_date()
+    hdfs_path = updatePathEnding(hdfs_path)
+    path = f'{hdfs_path}{year}/{mon}/{day}'
+    print("Copy backup to {}".format(path))
+    cmd = 'hadoop fs -mkdir -p {}'.format(path)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        print(output)
+    cmd = 'hadoop fs -put {} {}'.format(archive, path)
+    print('Execute: {}'.format(cmd))
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        print(output)
+    cmd = 'hadoop fs -ls {}'.format(path)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    print("New backup: {}".format(output))
+
+
+def copyToFileSystem(archive, base_dir):
+    day, mon, year = get_date()
+    base_dir = updatePathEnding(base_dir)
+    path = f'{base_dir}{year}/{mon}/{day}'
+    print("Copy backup to {}".format(path))
+    cmd = 'mkdir -p {}'.format(path)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        print(output)
+    cmd = 'cp {} {}'.format(archive, path)
+    print('Execute: {}'.format(cmd))
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        print(output)
+    cmd = 'ls {}'.format(path)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    print("New backup: {}".format(output))
+
+
+@click.command()
+@click.option("--token", "fname", required=True, help="Grafana token location JSON file")
+@click.option("--hdfs-path", required=True, help="Path for Grafana backup in HDFS")
+@click.option("--filesystem-path", required=True, help="Path for Grafana backup in EOS")
+def main(fname, hdfs_path, filesystem_path):
+    click.echo(f"Input Arguments: token:{fname}, hdfs_path:{hdfs_path}, filesystem_path:{filesystem_path}")
+    headers = getGrafanaAuth(fname)
+    searchFoldersFromGrafana(headers)
+    createTar('./grafana', 'grafanaBackup.tar.gz')
+    copyToHDFS('grafanaBackup.tar.gz', hdfs_path)
+    copyToFileSystem('grafanaBackup.tar.gz', filesystem_path)
+    removeTempFiles('./grafana/')
+
+
+if __name__ == '__main__':
+    main()

--- a/grafana-backup/dashboard-exporter.py
+++ b/grafana-backup/dashboard-exporter.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""
+Author: Nikodemas Tuckus <ntuckus AT gmail [DOT] com>
+This script copies Grafana dashboard jsons, tars them and puts them into HDFS and EOS folder
+"""
 import os
 import sys
 import json

--- a/grafana-backup/run.sh
+++ b/grafana-backup/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -l
+# shellcheck disable=SC1090
+
+# This script copies Grafana dashboard jsons, tar them and put into hdfs folder.
+# Ref for alerting: https://github.com/dmwm/CMSSpark/blob/master/bin/cron4aggregation
+
+##H Usage: run.sh TOKEN_LOCATION HDFS_PATH FILESYSTEM_PATH
+##H Example:
+##H        run.sh keys/token.json /cms/backups/grafana/ /eos/cms/store/group/offcomp_monit/
+
+# help definition
+if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == "help" ] || [ "$1" == "" ]; then
+    grep "^##H" <"$0" | sed -e "s,##H,,g"
+    exit 1
+fi
+
+# Change working directory
+cd "$(dirname "$0")" || exit
+
+addr=ceyhun.uzunoglu@cern.ch
+
+apath=/data/cms/anaconda3
+export PATH=$PATH:$apath/bin/
+if [ -f $apath/etc/profile.d/conda.sh ]; then
+
+  source $apath/etc/profile.d/conda.sh
+fi
+conda activate py3-stomp
+
+# Add cvmfs envs to run amtool
+export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+source $VO_CMS_SW_DIR/cmsset_default.sh
+
+# Call func function on exit
+trap onExit exit
+
+# Define func
+function onExit() {
+  local status=$?
+  if [ $status -ne 0 ]; then
+    local msg="Grafana backup cron failure. Please see vocms092:/data/cms/cmsmonitoringbackup/log"
+    if [ -f ./amtool ]; then
+      expire=$(date -d '+1 hour' --rfc-3339=ns | tr ' ' 'T')
+      local expire
+      local urls="http://cms-monitoring.cern.ch:30093 http://cms-monitoring-ha1.cern.ch:30093 http://cms-monitoring-ha2.cern.ch:30093"
+      for url in $urls; do
+        ./amtool alert add grafana_backup_failure \
+          alertname=grafana_backup_failure severity=monitoring tag=cronjob alert=amtool \
+          --end="$expire" \
+          --annotation=summary="$msg" \
+          --annotation=date="$(date)" \
+          --annotation=hostname="$(hostname)" \
+          --annotation=status="$status" \
+          --alertmanager.url="$url"
+      done
+    else
+      echo "$msg" | mail -s "Cron alert grafana_backup_failure" "$addr"
+    fi
+  fi
+}
+
+# Execute
+/data/cms/cmsmonitoringbackup/dashboard-exporter.py --token $1 --hdfs-path $2 --filesystem-path $3


### PR DESCRIPTION
CMSMONIT-531

We are moving cmsmonitoringbackup job from to Kubernetes cluster. For this a few changes are needed:
* code needs to be transferred to CMSMonitoring repository (therefore GitLab to GitHub)
* it will be using cmsmon-spark docker [image](https://github.com/dmwm/CMSKubernetes/tree/master/docker/cmsmon-spark) from the Kubernetes so the image needs to be updated accordingly
* authentication and alerting in run.sh needs to be changed as well so that it would work from Kubernetes