### PR TITLE
Tasks dump with sqoop

### DIFF
--- a/sqoop/configs-dev.json
+++ b/sqoop/configs-dev.json
@@ -7,5 +7,6 @@
   "cms-dbs3-files.sh": "/tmp/cmssqoop/dev-test/dbs3verify/CMS_DBS3_PROD_GLOBAL/files",
   "phedex-blk-replicas-snapshot.sh": "/tmp/cmssqoop/dev-test/phedex/block-replicas-snapshots/csv",
   "phedex-file-catalog.sh": "/tmp/cmssqoop/dev-test/phedex/catalog/csv",
-  "rucio_table_dumps.sh": "/tmp/cmssqoop/dev-test/rucio"
+  "rucio_table_dumps.sh": "/tmp/cmssqoop/dev-test/rucio",
+  "cms-tasks.sh": "/tmp/cmssqoop/dev-test/tasks"
 }

--- a/sqoop/configs.json
+++ b/sqoop/configs.json
@@ -7,5 +7,6 @@
   "cms-dbs3-files.sh": "/project/awg/cms/dbs3verify/CMS_DBS3_PROD_GLOBAL/files",
   "phedex-blk-replicas-snapshot.sh": "/project/awg/cms/phedex/block-replicas-snapshots/csv",
   "phedex-file-catalog.sh": "/project/awg/cms/phedex/catalog/csv",
-  "rucio_table_dumps.sh": "/project/awg/cms/rucio"
+  "rucio_table_dumps.sh": "/project/awg/cms/rucio",
+  "cms-tasks.sh": "/project/awg/cms/crab/tasks"
 }

--- a/sqoop/cronjobs.txt
+++ b/sqoop/cronjobs.txt
@@ -19,7 +19,10 @@ MAILTO=""
 # DBS full dumps
 00 05 * * *   cd /data/sqoop; ./run.sh ./scripts/dbs3_full_global.sh
 
-# Run only in production, paranthesis are important
+# TASKS dump
+00 02 * * *   cd /data/sqoop; ./run.sh ./scripts/cms-tasks.sh
+
+# Run only in production, parenthesis are important
 00 14 * * * [[ $CMSSQOOP_ENV == "prod" ]] && ( cd /data; /data/sqoop/run.sh /data/monit -query="stats" -token /etc/secrets/token -hdfs=/etc/secrets/hdfs.json -creds=/etc/secrets/cms-es-size.json -verbose 1 -inject 2>&1 1>& monit.log )
 
 # HDFS directories retention policy cleaner

--- a/sqoop/curator/hdfs_cleaner.sh
+++ b/sqoop/curator/hdfs_cleaner.sh
@@ -42,3 +42,9 @@ dbs_file_lumis_day_retention="30 days ago"
 dbs_file_lumis_dir="/project/awg/cms/dbs/PROD_GLOBAL"
 dbs_file_lumis_day=$(date -d "$dbs_file_lumis_day_retention" +%Y-%m-%d)
 util_hdfs_delete "$dbs_file_lumis_dir/$dbs_file_lumis_day/FILE_LUMIS" "DBS3 FILE_LUMIS"
+
+# TASKS (cms-tasks.sh | /project/awg/cms/crab/tasks) 30 days retention policy
+tasks_day_retention="30 days ago"
+tasks_dir="/project/awg/cms/crab/tasks"
+tasks_day=$(date -d "$tasks_day_retention" +%Y-%m-%d)
+util_hdfs_delete "$tasks_dir/$tasks_day" "TASKS"

--- a/sqoop/scripts/cms-tasks.sh
+++ b/sqoop/scripts/cms-tasks.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# shellcheck disable=SC2004
+# Import Oracle CMS_ANALYSIS_REQMGR.TASKS table using Apache Sqoop tool.
+#   - Imports full table without direct connection
+#   - Dumped to HDFS in avro format
+#
+
+set -e
+. "${WDIR}/sqoop/scripts/utils.sh"
+TZ=UTC
+
+# --------------------------------------------------------------------------------- PREPS
+SCHEMA="CMS_ANALYSIS_REQMGR"
+TABLE="TASKS"
+NUM_MAPPERS=8
+
+# ------------------------------------------------------------------------------- GLOBALS
+myname=$(basename "$0")
+BASE_PATH=$(util_get_config_val "$myname")
+DAILY_PATH="${BASE_PATH}/$(date +%Y-%m-%d)"
+START_TIME=$(date +%s)
+pg_metric_db="CRAB_TASKS"
+util4logi "CMSSQOOP_ENV=${CMSSQOOP_ENV}, CMSSQOOP_CONFIGS=${CMSSQOOP_CONFIGS}." >>"$LOG_FILE".stdout
+
+# Check hadoop executable exist
+if ! [ -x "$(command -v hadoop)" ]; then
+    echo "[ERROR] It seems 'hadoop' does not exist in PATH! Exiting..." >>"$LOG_FILE".stdout
+    exit 1
+fi
+
+# -------------------------------------------------------------------------------- CHECKS
+if [ -f /etc/secrets/cmsr_cstring ]; then
+    JDBC_URL=$(sed '1q;d' /etc/secrets/cmsr_cstring)
+    USERNAME=$(sed '2q;d' /etc/secrets/cmsr_cstring)
+    PASSWORD=$(sed '3q;d' /etc/secrets/cmsr_cstring)
+else
+    util4loge "Unable to read the credentials" >>"$LOG_FILE".stdout
+    exit 1
+fi
+
+# --------------------------------------------------------------------------------- UTILS
+trap 'onFailExit' ERR
+onFailExit() {
+    util4loge "Finished with error! $(dirname "$0")" >>"$LOG_FILE".stdout
+    util4loge "FAILED" >>"$LOG_FILE".stdout
+    exit 1
+}
+
+# ------------------------------------------------------------------------- DUMP FUNCTION
+# Dumps TASKS table in avro format
+# shellcheck disable=SC2086
+sqoop_dump_tasks_cmd() {
+    local local_start_time
+    local_start_time=$(date +%s)
+    trap 'onFailExit' ERR
+    kinit -R
+
+    util4logi "${SCHEMA}.${TABLE} : import starting with num-mappers as $NUM_MAPPERS .."
+    pushg_dump_start_time "$myname" "$pg_metric_db" "$SCHEMA" "$TABLE"
+    #
+    /usr/hdp/sqoop/bin/sqoop import \
+      -Dmapreduce.job.user.classpath.first=true \
+      -Ddfs.client.socket-timeout=120000 \
+      -Dmapred.child.java.opts="-Djava.security.egd=file:/dev/../dev/urandom" \
+      --username "$USERNAME" --password "$PASSWORD" -z --throw-on-error --connect "$JDBC_URL" \
+      --num-mappers $NUM_MAPPERS \
+      --split-by TM_START_TIME \
+      --fetch-size 3000 \
+      --map-column-java TM_TASK_FAILURE=String,TM_SPLIT_ARGS=String,TM_OUTFILES=String,TM_TFILE_OUTFILES=String,TM_EDM_OUTFILES=String,TM_ARGUMENTS=String,PANDA_RESUBMITTED_JOBS=String,TM_OUTPUT_DATASET=String,TM_TASK_WARNINGS=String,TM_USER_FILES=String,TM_USER_CONFIG=String \
+      --target-dir "$DAILY_PATH" \
+      --table \""$SCHEMA"."$TABLE"\" \
+      --as-avrodatafile \
+      1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
+    #
+    util4logi "${SCHEMA}.${TABLE} : import finished successfully in $(util_secs_to_human "$(($(date +%s) - local_start_time))")"
+    pushg_dump_end_time "$myname" "$pg_metric_db" "$SCHEMA" "$TABLE"
+}
+
+# ----------------------------------------------------------------------------------- RUN
+
+# Run import
+sqoop_dump_crab_cmd >>"$LOG_FILE".stdout 2>&1
+
+# Give read permission to the new folder and sub folders after the dump is finished
+hadoop fs -chmod -R o+rx "$DAILY_PATH"
+
+# ---------------------------------------------------------------------------- STATISTICS
+# total duration
+duration=$(($(date +%s) - START_TIME))
+# Dumped tables total size in bytes
+dump_size=$(util_hdfs_size "$DAILY_PATH")
+
+# Pushgateway
+pushg_dump_duration "$myname" "$pg_metric_db" "$SCHEMA" $duration
+pushg_dump_size "$myname" "$pg_metric_db" "$SCHEMA" "$dump_size"
+
+util4logi "all finished, time spent: $(util_secs_to_human $duration)" >>"$LOG_FILE".stdout

--- a/sqoop/scripts/cms-tasks.sh
+++ b/sqoop/scripts/cms-tasks.sh
@@ -19,7 +19,8 @@ myname=$(basename "$0")
 BASE_PATH=$(util_get_config_val "$myname")
 DAILY_PATH="${BASE_PATH}/$(date +%Y-%m-%d)"
 START_TIME=$(date +%s)
-pg_metric_db="CRAB_TASKS"
+LOG_FILE=log/$(date +'%F_%H%M%S')_$myname
+pg_metric_db="TASKS"
 util4logi "CMSSQOOP_ENV=${CMSSQOOP_ENV}, CMSSQOOP_CONFIGS=${CMSSQOOP_CONFIGS}." >>"$LOG_FILE".stdout
 
 # Check hadoop executable exist
@@ -79,7 +80,7 @@ sqoop_dump_tasks_cmd() {
 # ----------------------------------------------------------------------------------- RUN
 
 # Run import
-sqoop_dump_crab_cmd >>"$LOG_FILE".stdout 2>&1
+sqoop_dump_tasks_cmd >>"$LOG_FILE".stdout 2>&1
 
 # Give read permission to the new folder and sub folders after the dump is finished
 hadoop fs -chmod -R o+rx "$DAILY_PATH"


### PR DESCRIPTION
CMSMONIT-549

Daily dump of `CMS_ANALYSIS_REQMGR.TASKS` table that will be run on `cron` Kubernetes cluster:
- finished dump script
- updated configs
- updated HDFS cleaner script so that it would delete old dumps of this table

Another small PR incoming in the CMSKubernetes repository regarding this.

FYI @leggerf @brij01 @novicecpp 