### PR TITLE
Update monit tools GH pipeline

### DIFF
--- a/.github/workflows/build-go-tools.yml
+++ b/.github/workflows/build-go-tools.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir cmsmon-tools
           cd src/go/MONIT
-          go build -o monit monit.go
+          go build -o monit monit.go -s -w -extldflags -static
           go build -o alert alert.go
           go build -o annotationManager annotationManager.go
           go build -o datasources datasources.go


### PR DESCRIPTION
We got an issue on our previous release (see https://github.com/cms-sw/cmsdist/pull/8682#issuecomment-1711731431).

Therefore, here is a fix suggested by @vkuznet:

> to fix this issue you should change CI/CD workflow files which build go tools to
> build their static executable.
> ```
> go build -o monit monit.go
> ```
> This command by default builds shared version of the executable. To make static
> version you should change it to
> ```
> go build -o monit monit.go -s -w -extldflags -static
> ```
> Then, the new executable will no longer depends on specific GLIBC version.
