### PR TITLE
Change the syntax of go command

### DIFF
--- a/.github/workflows/build-go-tools.yml
+++ b/.github/workflows/build-go-tools.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           mkdir cmsmon-tools
           cd src/go/MONIT
-          go build -o monit monit.go -s -w -extldflags -static
+          go build -ldflags "-s -w -extldflags '-static'" -o monit monit.go
           go build -o alert alert.go
           go build -o annotationManager annotationManager.go
           go build -o datasources datasources.go


### PR DESCRIPTION
After the build [workflow](https://github.com/dmwm/CMSMonitoring/actions/runs/6156256171) from the previous [PR](https://github.com/dmwm/CMSMonitoring/pull/238) failed, syntax of the command had to be changed. See [this article](https://mt165.co.uk/blog/static-link-go/) about that.

FYI @vkuznet @leggerf @brij01 