### PR TITLE
Update cpueff_stepchain_goweb.py

### DIFF
--- a/cpueff-goweb/spark/cpueff_stepchain_goweb.py
+++ b/cpueff-goweb/spark/cpueff_stepchain_goweb.py
@@ -70,7 +70,7 @@ def udf_step_extract(row):
     _fwjr_id = row['meta_data']['fwjr_id']
     _jobtype = row['meta_data']['jobtype']
     _ts = row['meta_data']['ts']
-    if 'steps' in row:
+    if 'steps' in row and row['steps']:
         for step in row['steps']:
             if ('name' in step) and step['name'].lower().startswith('cmsrun'):
                 step_res = {'Task': _task_name, 'ts': _ts, 'fwjr_id': _fwjr_id, 'JobType': _jobtype}


### PR DESCRIPTION
This script has been failing with the message `'NoneType' object is not iterable` for quite a long time and this additional check for `NoneType` should fix it. Same issue as https://github.com/dmwm/CMSSpark/pull/155.

FYI @leggerf @brij01 