### PR TITLE
Upgrade jsonschema package as it is not compatible with one used by rucio

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 click
 stomp.py>=6.1.1,<8.0.0
-jsonschema~=3.2.0
+jsonschema>=4.20.0
 nats-py ; python_version >= '3.7' # Ref https://github.com/nats-io/nats.py
 # requests
 # numpy


### PR DESCRIPTION
We found incompatibilities of `jsonschema` python package used by rucio and CMS Monitoring. The rucio requires version `jsonschema>=4.20.0` while here we still used `jsonschema~=3.2.0`. Because of this conflict the WM stack cannot be upgraded as it depends both on CMSMonitoring and rucio clients. To align the `jsonschema` version I provide here the upgrade of its dependencies to align with rucio clients.

FYI: @amaltaro 