### PR TITLE
Add requests table to RUCIO_TABLES variable

### DIFF
--- a/sqoop/scripts/rucio_table_dumps.sh
+++ b/sqoop/scripts/rucio_table_dumps.sh
@@ -9,7 +9,7 @@ export PATH="$PATH:/usr/hdp/sqoop/bin/"
 TZ=UTC
 SCHEMA="CMS_RUCIO_PROD"
 # Suggested order
-RUCIO_TABLES="replicas dids contents dataset_locks locks rules rules_history requests_history subscriptions rses accounts account_limits bad_replicas deleted_dids rse_attr_map"
+RUCIO_TABLES="replicas dids contents dataset_locks locks rules rules_history requests requests_history subscriptions rses accounts account_limits bad_replicas deleted_dids rse_attr_map"
 
 myname=$(basename "$0")
 BASE_PATH=$(util_get_config_val "$myname")


### PR DESCRIPTION
As per request of @eachristgr, we are adding the requests table to the Rucio table dumps.

The order of the elements inside the RUCIO_TABLES variable  is important, as they will get snapshotted in that order.
In this case, we want to dump the requests and requests_history tables as close together as possible to avoid any possible data mismatches between them.