### PR TITLE
Update collectors.json : cmssrv276.fnal.gov is obsolete

### DIFF
--- a/docker/spider-query-cronjob/collectors.json
+++ b/docker/spider-query-cronjob/collectors.json
@@ -1,5 +1,5 @@
 {
-    "Global":["cmsgwms-collector-global.cern.ch:9620", "cmsgwms-collector-global.fnal.gov:9620","cmssrv276.fnal.gov"],
+    "Global":["cmsgwms-collector-global.cern.ch:9620", "cmsgwms-collector-global.fnal.gov:9620"],
     "Tier0":["cmsgwms-collector-tier0.cern.ch:9620","cmsgwms-collector-tier0.fnal.gov:9620"],
     "Volunteer":["vocms0840.cern.ch"],
     "ITB":["cmsgwms-collector-itb.cern.ch"],


### PR DESCRIPTION
Removed one global collector from the configuration.