### PR TITLE
Refactor Grafana cronjobs to be migrated to the Opentofu cluster

### DIFF
--- a/docker/grafana-daily-backup/Dockerfile
+++ b/docker/grafana-daily-backup/Dockerfile
@@ -1,0 +1,5 @@
+# Image in the registry: registry.cern.ch/cmsmonitoring/grafana-daily-backup
+FROM registry.cern.ch/cmsmonitoring/cmsmon-py:4.0.0
+
+# Copy only the specific files you need instead of cloning entire repos
+COPY src/ ./

--- a/docker/grafana-daily-backup/README.md
+++ b/docker/grafana-daily-backup/README.md
@@ -1,0 +1,16 @@
+# Grafana dashboard exporter cron job
+
+Docker image for the grafana-dashboard-exporter Kubernetes CronJob. Exports CMS Monitoring Grafana dashboard JSON definitions, compresses them, and writes the archive to EOS at `/eos/cms/store/group/offcomp_monit/grafana_backup`.
+
+Built on `cmsmon-py` (`helpers/otel_setup.py`). Set `OTEL_ENABLED=true` and `OTEL_SERVICE_NAME` in the Kubernetes cronjob to export logs to the OpenTelemetry Collector.
+
+## Build and publish
+
+```sh
+docker build -t registry.cern.ch/cmsmonitoring/grafana-dashboard-exporter:test .
+docker push registry.cern.ch/cmsmonitoring/grafana-dashboard-exporter:test
+```
+
+## Kubernetes deployment
+
+CronJob definition: `cmsmon-opentofu/modules/kubernetes/submodules/cronjobs/cron_grafana_dashboard_exporter.tf`

--- a/docker/grafana-daily-backup/src/cron4grafana_daily_backup.sh
+++ b/docker/grafana-daily-backup/src/cron4grafana_daily_backup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+##H Script to export Grafana dashboards and archive them to EOS
+##H CMSVOC and CMSMONITORING groups are responsible for this script.
+set -e
+TZ=UTC
+myname=$(basename "$0")
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Get nice util functions
+. "${script_dir}"/utils.sh
+
+if [ -z "$K8S_ENV" ]; then
+    util4loge "K8S_ENV is not set. This script is intended to run in Kubernetes."
+    exit 1
+fi
+
+py_input_args=(
+    --token "/etc/grafana-secrets/grafana-token.json"
+    --filesystem-path "/eos/cms/store/group/offcomp_monit/grafana_backup"
+)
+
+export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-grafana-daily-backup}"
+
+util4logi "${myname} is starting.."
+util_cron_send_start "$myname" "1d"
+
+util_kerberos_auth_with_keytab /etc/secrets/keytab
+python3 "${script_dir}"/daily_backup.py "${py_input_args[@]}"
+
+util_cron_send_end "$myname" "1d" "$?"
+util4logi "${myname} successfully finished."

--- a/docker/grafana-daily-backup/src/daily_backup.py
+++ b/docker/grafana-daily-backup/src/daily_backup.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Author: Nikodemas Tuckus <ntuckus AT gmail [DOT] com>
+This script copies Grafana dashboard jsons, tars them and puts them into EOS folder
+"""
+import datetime
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import click
+import requests
+from helpers.otel_setup import shutdown_opentelemetry
+
+logger = logging.getLogger(__name__)
+
+base_url = "https://monit-grafana.cern.ch/api"
+grafana_folder = "./grafana"
+tar_file_name = "grafanaBackup.tar.gz"
+GRAFANA_ORG_ID = 11
+BACKUP_FOLDERS = ["Production", "Development", "Playground", "Backup"]
+GENERAL_FOLDER_UID = "general"
+
+
+def get_grafana_auth(fname):
+    if not os.path.exists(fname):
+        logger.error("File %s does not exist", fname)
+        sys.exit(1)
+    with open(fname, "r") as keyFile:
+        secret_key = json.load(keyFile).get("filesystem_exporter_token")
+    headers = {
+        "Authorization": f"Bearer {secret_key}",
+        "X-Grafana-Org-Id": str(GRAFANA_ORG_ID),
+    }
+    return headers
+
+
+def create_backup_files(dashboard, folder_title, headers):
+    all_json = []
+
+    dashboard_uid = dashboard.get("uid")
+    path = f"grafana/dashboards/{folder_title}"
+
+    if not os.path.exists(path):
+        try:
+            os.makedirs(os.path.join("grafana", "dashboards", folder_title))
+            logger.info("Successfully created the directory %s", path)
+        except OSError:
+            logger.error("Creation of the directory %s failed", path)
+    dashboard_url = f"{base_url}/dashboards/uid/{dashboard_uid}"
+    logger.info("dashboard_url %s", dashboard_url)
+    req = requests.get(
+        dashboard_url,
+        headers=headers,
+        params={"orgId": GRAFANA_ORG_ID},
+    )
+    if req.status_code == 403:
+        logger.warning(
+            "Skipping dashboard uid %s (%s): forbidden — service account lacks dashboards:read",
+            dashboard_uid,
+            dashboard.get("title", "unknown"),
+        )
+        return False
+    req.raise_for_status()
+    dashboard_data = req.json().get("dashboard")
+    if not dashboard_data:
+        logger.error("No dashboard data returned for uid %s", dashboard_uid)
+        return False
+
+    # Replace characters that might cause harm
+    title_of_dashboard = (
+        dashboard_data.get("title").replace(" ", "").replace(".", "_").replace("/", "_")
+    )
+    uid_of_dashboard = dashboard_data.get("uid")
+
+    filename_for_folder = f"{path}/{title_of_dashboard}-{uid_of_dashboard}.json"
+    logger.info("filename_for_folder %s", filename_for_folder)
+    with open(filename_for_folder, "w+") as jsonFile:
+        json.dump(dashboard_data, jsonFile)
+    all_json.append(dashboard_data)
+
+    filename_for_all_json = f"{path}/all.json"
+    logger.info("filename_for_all_json %s", filename_for_all_json)
+    with open(filename_for_all_json, "w+") as jsonFile:
+        json.dump(all_json, jsonFile)
+    return True
+
+
+def get_folders(headers):
+    response = requests.get(
+        f"{base_url}/folders",
+        headers=headers,
+        params={"orgId": GRAFANA_ORG_ID},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_dashboards_in_folder(headers, folder_uid):
+    response = requests.get(
+        f"{base_url}/search",
+        headers=headers,
+        params={
+            "folderUIDs": folder_uid,
+            "type": "dash-db",
+            "orgId": GRAFANA_ORG_ID,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def search_folders_from_grafana(headers):
+    dashboards_exported = 0
+    path_to_db = os.path.abspath("grafana")
+    os.makedirs(path_to_db, exist_ok=True)
+
+    folders = get_folders(headers)
+    folder_by_title = {folder["title"]: folder for folder in folders}
+
+    for folder_title in BACKUP_FOLDERS:
+        folder = folder_by_title.get(folder_title)
+        if not folder:
+            logger.warning("Folder '%s' not found, skipping", folder_title)
+            continue
+
+        folder_id = folder["id"]
+        folder_uid = folder["uid"]
+        folder_data = get_dashboards_in_folder(headers, folder_uid)
+
+        filename_for_folder = f"grafana/{folder_id}-{folder_title}.json"
+        with open(filename_for_folder, "w+") as jsonFile:
+            json.dump(folder_data, jsonFile)
+
+        dashboards_amount = len(folder_data)
+        for index, dashboard in enumerate(folder_data):
+            logger.info("Index/Amount: %s/%s", index, dashboards_amount)
+            if create_backup_files(dashboard, folder_title, headers):
+                dashboards_exported += 1
+
+    general_dashboards = get_dashboards_in_folder(headers, GENERAL_FOLDER_UID)
+    general_amount = len(general_dashboards)
+    for index, dashboard in enumerate(general_dashboards):
+        logger.info("General Index/Amount: %s/%s", index, general_amount)
+        if create_backup_files(dashboard, "General", headers):
+            dashboards_exported += 1
+
+    if dashboards_exported == 0:
+        logger.error("No dashboards exported, aborting")
+        sys.exit(1)
+
+
+def create_tar(path, tar_name):
+    if not os.path.isdir(path) or not any(os.scandir(path)):
+        logger.error("Nothing to archive in %s", path)
+        sys.exit(1)
+
+    with tarfile.open(tar_name, "w:gz") as tar_handle:
+        for root, _, files in os.walk(path):
+            for file in files:
+                tar_handle.add(os.path.join(root, file))
+
+    tar_size = os.path.getsize(tar_name)
+    logger.info("Created archive %s (%d bytes)", tar_name, tar_size)
+    if tar_size < 100:
+        logger.error("Archive %s is too small (%d bytes), aborting", tar_name, tar_size)
+        sys.exit(1)
+
+
+def remove_temp_files(path):
+    for root, dirs, files in os.walk(path):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))
+    if os.path.exists(path):
+        os.rmdir(path)
+
+
+def get_date():
+    dt = datetime.datetime.now().strftime("%Y/%m/%d")
+    return dt
+
+
+def copy_to_filesystem(archive, base_dir):
+    dt = get_date()
+    path = os.path.join(base_dir, dt)
+    logger.info("Copy backup to %s", path)
+    cmd = f"mkdir -p {path}"
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        logger.info(output.decode())
+    cmd = f"cp {archive} {path}"
+    logger.info("Execute: %s", cmd)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    if output:
+        logger.info(output.decode())
+    cmd = f"ls {path}"
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    logger.info("New backup: %s", output.decode())
+
+
+@click.command()
+@click.option(
+    "--token", "fname", required=True, help="Grafana token JSON file location"
+)
+@click.option("--filesystem-path", required=True, help="Path for Grafana backup in EOS")
+def main(fname, filesystem_path):
+    logger.info("Input Arguments: token:%s, filesystem_path:%s", fname, filesystem_path)
+    headers = get_grafana_auth(fname)
+    search_folders_from_grafana(headers)
+    create_tar(grafana_folder, tar_file_name)
+    copy_to_filesystem(tar_file_name, filesystem_path)
+    remove_temp_files(grafana_folder)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        shutdown_opentelemetry()

--- a/docker/grafana-production-copy/Dockerfile
+++ b/docker/grafana-production-copy/Dockerfile
@@ -1,0 +1,5 @@
+# Image in the registry: registry.cern.ch/cmsmonitoring/grafana-production-copy
+FROM registry.cern.ch/cmsmonitoring/cmsmon-py:4.0.0
+
+# Copy only the specific files you need instead of cloning entire repos
+COPY src/ ./

--- a/docker/grafana-production-copy/README.md
+++ b/docker/grafana-production-copy/README.md
@@ -1,0 +1,16 @@
+# Grafana dashboard copy cron job
+
+Docker image for the grafana-dashboard-copy Kubernetes CronJob. Copies Grafana dashboards from the "Production" folder to "Production Copy" via the Grafana API.
+
+Built on `cmsmon-py` (`helpers/otel_setup.py`). Set `OTEL_ENABLED=true` and `OTEL_SERVICE_NAME` in the Kubernetes cronjob to export logs to the OpenTelemetry Collector.
+
+## Build and publish
+
+```sh
+docker build -t registry.cern.ch/cmsmonitoring/grafana-dashboard-copy:test docker/grafana-dashboard-copy
+docker push registry.cern.ch/cmsmonitoring/grafana-dashboard-copy:test
+```
+
+## Kubernetes deployment
+
+CronJob definition: `cmsmon-opentofu/modules/kubernetes/submodules/cronjobs/cron_grafana_dashboard_copy.tf`

--- a/docker/grafana-production-copy/src/cron4grafana_production_copy.sh
+++ b/docker/grafana-production-copy/src/cron4grafana_production_copy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+##H Script to copy Grafana dashboards from Production to Production Copy
+##H CMSVOC and CMSMONITORING groups are responsible for this script.
+set -e
+TZ=UTC
+myname=$(basename "$0")
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Get nice util functions
+. "${script_dir}"/utils.sh
+
+if [ -z "$K8S_ENV" ]; then
+    util4loge "K8S_ENV is not set. This script is intended to run in Kubernetes."
+    exit 1
+fi
+
+py_input_args=(
+    --url "https://monit-grafana.cern.ch"
+    --token "/etc/grafana-secrets/grafana-token.json"
+)
+
+export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-grafana-production-copy}"
+
+util4logi "${myname} is starting.."
+util_cron_send_start "$myname" "1d"
+
+python3 "${script_dir}"/production_copy.py "${py_input_args[@]}"
+
+util_cron_send_end "$myname" "1d" "$?"
+util4logi "${myname} successfully finished."

--- a/docker/grafana-production-copy/src/production_copy.py
+++ b/docker/grafana-production-copy/src/production_copy.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This script copies Grafana dashboards from one folder to another.
+"""
+import datetime
+import json
+import logging
+import sys
+
+import click
+import requests
+from helpers.otel_setup import shutdown_opentelemetry
+
+logger = logging.getLogger(__name__)
+
+GRAFANA_ORG_ID = 11
+
+
+def get_grafana_auth(fname):
+    """Load Grafana authentication token from a file."""
+    with open(fname, "r") as token_file:
+        token = json.load(token_file)["production_copy_token"]
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def get_folder_uid(base_url, headers, folder_name):
+    """Fetch the folder UID for a given folder name."""
+    response = requests.get(
+        f"{base_url}/api/folders",
+        headers=headers,
+        params={"orgId": GRAFANA_ORG_ID},
+    )
+    response.raise_for_status()
+    for folder in response.json():
+        if folder["title"] == folder_name:
+            return folder["uid"]
+    return None
+
+
+def get_folder_permissions(base_url, headers, folder_uid):
+    """Fetch the permissions of a folder."""
+    response = requests.get(f"{base_url}/api/folders/{folder_uid}/permissions", headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def update_folder_permissions(base_url, headers, folder_uid, permissions):
+    """Set permissions for a folder."""
+    payload = {"items": permissions}
+    response = requests.post(f"{base_url}/api/folders/{folder_uid}/permissions", headers=headers, json=payload)
+    response.raise_for_status()
+    logger.info("Permissions for folder UID '%s' have been updated.", folder_uid)
+
+
+def delete_folder(base_url, headers, folder_uid):
+    """Delete a folder by its UID."""
+    response = requests.delete(f"{base_url}/api/folders/{folder_uid}", headers=headers)
+    response.raise_for_status()
+    logger.info("Deleted folder with UID %s.", folder_uid)
+
+
+def create_folder(base_url, headers, folder_name):
+    """Create a folder. If it exists, delete and recreate it while preserving permissions."""
+    folder_uid = get_folder_uid(base_url, headers, folder_name)
+    preserved_permissions = []
+
+    if folder_uid:
+        logger.info("Folder '%s' exists. Fetching permissions and overwriting...", folder_name)
+        preserved_permissions = get_folder_permissions(base_url, headers, folder_uid)
+        delete_folder(base_url, headers, folder_uid)
+
+    response = requests.post(f"{base_url}/api/folders", headers=headers, json={"title": folder_name})
+    response.raise_for_status()
+    folder = response.json()
+    logger.info("Created folder '%s'.", folder_name)
+
+    if preserved_permissions:
+        update_folder_permissions(base_url, headers, folder["uid"], preserved_permissions)
+
+    return folder["id"]
+
+
+def get_dashboards_in_folder(base_url, headers, folder_uid):
+    """Fetch all dashboards in a folder."""
+    response = requests.get(
+        f"{base_url}/api/search",
+        headers=headers,
+        params={"folderUIDs": folder_uid, "type": "dash-db", "orgId": GRAFANA_ORG_ID},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def copy_dashboard(base_url, headers, dashboard, target_folder_id):
+    """Copy a dashboard to a new folder."""
+    dashboard_uid = dashboard["uid"]
+    response = requests.get(f"{base_url}/api/dashboards/uid/{dashboard_uid}", headers=headers)
+    response.raise_for_status()
+    dashboard_data = response.json()
+    dashboard_data["dashboard"]["id"] = None
+    dashboard_data["dashboard"]["uid"] = None
+    dashboard_data["folderId"] = target_folder_id
+    dashboard_data["message"] = f"Copied on {datetime.datetime.now()}"
+    response = requests.post(f"{base_url}/api/dashboards/db", headers=headers, json=dashboard_data)
+    response.raise_for_status()
+    logger.info("Copied dashboard '%s' to folder ID %s.", dashboard["title"], target_folder_id)
+
+
+@click.command()
+@click.option("--url", required=True, help="Base URL of the Grafana instance")
+@click.option("--token", "fname", required=True, help="API or Service Account token for authentication")
+def main(url, fname):
+    headers = get_grafana_auth(fname)
+    source_folder_name = "Production"
+    target_folder_name = "Production Copy"
+
+    source_folder_uid = get_folder_uid(url, headers, source_folder_name)
+    if not source_folder_uid:
+        logger.error("Source folder '%s' does not exist.", source_folder_name)
+        return
+
+    dashboards = get_dashboards_in_folder(url, headers, source_folder_uid)
+    logger.info("Found %s dashboards in '%s'.", len(dashboards), source_folder_name)
+    if not dashboards:
+        logger.error(
+            "No dashboards found in '%s'. Aborting without modifying '%s'.",
+            source_folder_name,
+            target_folder_name,
+        )
+        return
+
+    target_folder_id = create_folder(url, headers, target_folder_name)
+
+    for dashboard in dashboards:
+        copy_dashboard(url, headers, dashboard, target_folder_id)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error("An unexpected error occurred: %s", e)
+        sys.exit(1)
+    finally:
+        shutdown_opentelemetry()


### PR DESCRIPTION
As pointed by [CMSMONIT-736](https://its.cern.ch/jira/browse/CMSMONIT-736), we are migrating the Grafana related cronjobs (production-copy and daily-backup) into the Opentofu cluster.

For that, we are refactoring the code so that they work as docker images based off of cmsmon-py, and have the same  Opentelemetry connections wired up for observability as all the other cronjob workloads.

Both images have already been tested and are running as cronjobs in the Opentofu cluster.